### PR TITLE
CEDS-1912 Refactor summary controllers for consistency

### DIFF
--- a/app/controllers/consolidations/AssociateUcrConfirmationController.scala
+++ b/app/controllers/consolidations/AssociateUcrConfirmationController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.consolidations
+
+import controllers.actions.{AuthenticatedAction, JourneyRefiner}
+import controllers.storage.FlashKeys
+import javax.inject.Inject
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import services.SubmissionService
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.associate_ucr_confirmation
+
+import scala.concurrent.ExecutionContext
+
+class AssociateUcrConfirmationController @Inject()(
+  authenticate: AuthenticatedAction,
+  mcc: MessagesControllerComponents,
+  associateUCRConfirmPage: associate_ucr_confirmation
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport {
+
+  def display: Action[AnyContent] = authenticate { implicit request =>
+    (request2flash.get(FlashKeys.CONSOLIDATION_KIND), request2flash.get(FlashKeys.UCR)) match {
+      case (Some(kind), Some(ucr)) => Ok(associateUCRConfirmPage(kind, ucr))
+      case _                       => Redirect(controllers.routes.ChoiceController.displayPage)
+    }
+
+  }
+
+}

--- a/app/controllers/consolidations/AssociateUcrController.scala
+++ b/app/controllers/consolidations/AssociateUcrController.scala
@@ -32,7 +32,7 @@ import views.html.associate_ucr
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class AssociateUCRController @Inject()(
+class AssociateUcrController @Inject()(
   authenticate: AuthenticatedAction,
   getJourney: JourneyRefiner,
   mcc: MessagesControllerComponents,
@@ -62,7 +62,7 @@ class AssociateUCRController @Inject()(
         formData => {
           val updatedCache = request.answersAs[AssociateUcrAnswers].copy(associateUcr = Some(formData))
           movementRepository.upsert(Cache(request.pid, updatedCache)).map { _ =>
-            Redirect(consolidationRoutes.AssociateUCRSummaryController.displayPage())
+            Redirect(consolidationRoutes.AssociateUcrSummaryController.displayPage())
           }
         }
       )

--- a/app/controllers/consolidations/AssociateUcrSummaryController.scala
+++ b/app/controllers/consolidations/AssociateUcrSummaryController.scala
@@ -17,6 +17,7 @@
 package controllers.consolidations
 
 import controllers.actions.{AuthenticatedAction, JourneyRefiner}
+import controllers.storage.FlashKeys
 import javax.inject.Inject
 import models.ReturnToStartException
 import models.cache.AssociateUcrAnswers
@@ -28,13 +29,12 @@ import views.html.{associate_ucr_confirmation, associate_ucr_summary}
 
 import scala.concurrent.ExecutionContext
 
-class AssociateUCRSummaryController @Inject()(
+class AssociateUcrSummaryController @Inject()(
   authenticate: AuthenticatedAction,
   getJourney: JourneyRefiner,
   mcc: MessagesControllerComponents,
   submissionService: SubmissionService,
-  associateUcrSummaryPage: associate_ucr_summary,
-  associateUCRConfirmPage: associate_ucr_confirmation
+  associateUcrSummaryPage: associate_ucr_summary
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
@@ -54,7 +54,8 @@ class AssociateUCRSummaryController @Inject()(
     val associateUcr = answers.associateUcr.getOrElse(throw ReturnToStartException)
 
     submissionService.submit(request.pid, answers).map { _ =>
-      Ok(associateUCRConfirmPage(associateUcr.kind.formValue, associateUcr.ucr))
+      Redirect(controllers.consolidations.routes.AssociateUcrConfirmationController.display())
+        .flashing(FlashKeys.UCR -> associateUcr.ucr, FlashKeys.CONSOLIDATION_KIND -> associateUcr.kind.formValue)
     }
   }
 }

--- a/app/controllers/consolidations/MucrOptionsController.scala
+++ b/app/controllers/consolidations/MucrOptionsController.scala
@@ -52,7 +52,7 @@ class MucrOptionsController @Inject()(
         validForm => {
           val updatedCache = request.answersAs[AssociateUcrAnswers].copy(mucrOptions = Some(validForm))
           movementRepository.upsert(Cache(request.pid, updatedCache)).map { _ =>
-            Redirect(consolidationsRoutes.AssociateUCRController.displayPage())
+            Redirect(consolidationsRoutes.AssociateUcrController.displayPage())
           }
         }
       )

--- a/app/views/associate_ucr.scala.html
+++ b/app/views/associate_ucr.scala.html
@@ -26,7 +26,7 @@
 @(form: Form[AssociateUcr], mucrOptions: MucrOptions)(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Title(messages("associate.ucr.title", mucrOptions.mucr))) {
-    @helper.form(consolidations.routes.AssociateUCRController.submit(), 'autoComplete -> "off") {
+    @helper.form(consolidations.routes.AssociateUcrController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
         @components.back_link(consolidations.routes.MucrOptionsController.displayPage())

--- a/app/views/associate_ucr_summary.scala.html
+++ b/app/views/associate_ucr_summary.scala.html
@@ -24,10 +24,10 @@
 
 @main_template(title = Title(messages("associate.ucr.summary.title", mucr)), fullWidth = true) {
 
-    @helper.form(consolidations.routes.AssociateUCRSummaryController.submit(), 'autoComplete -> "off") {
+    @helper.form(consolidations.routes.AssociateUcrSummaryController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
-        @components.back_link(consolidations.routes.AssociateUCRController.displayPage())
+        @components.back_link(consolidations.routes.AssociateUcrController.displayPage())
 
         @components.page_title(
             title = Some("associate.ucr.summary.title")
@@ -41,7 +41,7 @@
                     <td id="associate_ucr-type">@messages(s"associate.ucr.summary.kind.${associateUcr.kind.formValue}")</td>
                     <td id="associate_ucr-reference">@associateUcr.ucr</td>
                     <td class="text-right">
-                        <a id="associate_ducr-change" href="@consolidations.routes.AssociateUCRController.displayPage()">@messages("site.change")</a>
+                        <a id="associate_ducr-change" href="@consolidations.routes.AssociateUcrController.displayPage()">@messages("site.change")</a>
                     </td>
                 </tr>
             </tbody>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,22 +1,25 @@
 # microservice specific routes
-GET         /assets/*file                          controllers.Assets.versioned(path="/public", file: Asset)
+GET         /assets/*file                         controllers.Assets.versioned(path="/public", file: Asset)
 
 # Declaration choice page
-GET         /choice                                controllers.ChoiceController.displayPage()
-GET         /choice/:journey                       controllers.ChoiceController.startSpecificJourney(journey)
-POST        /choice                                controllers.ChoiceController.submit()
+GET         /choice                               controllers.ChoiceController.displayPage()
+GET         /choice/:journey                      controllers.ChoiceController.startSpecificJourney(journey)
+POST        /choice                               controllers.ChoiceController.submit()
 
 # MUCR options page
-GET         /mucr-options                          controllers.consolidations.MucrOptionsController.displayPage()
-POST        /mucr-options                          controllers.consolidations.MucrOptionsController.submit()
+GET         /mucr-options                         controllers.consolidations.MucrOptionsController.displayPage()
+POST        /mucr-options                         controllers.consolidations.MucrOptionsController.submit()
 
 # Associate UCR page
-GET         /associate-ucr                         controllers.consolidations.AssociateUCRController.displayPage()
-POST        /associate-ucr                         controllers.consolidations.AssociateUCRController.submit()
+GET         /associate-ucr                        controllers.consolidations.AssociateUcrController.displayPage()
+POST        /associate-ucr                        controllers.consolidations.AssociateUcrController.submit()
 
 # Associate UCR summary page
-GET         /associate-ucr-summary                 controllers.consolidations.AssociateUCRSummaryController.displayPage()
-POST        /associate-ucr-summary                 controllers.consolidations.AssociateUCRSummaryController.submit()
+GET         /associate-ucr-summary                controllers.consolidations.AssociateUcrSummaryController.displayPage()
+POST        /associate-ucr-summary                controllers.consolidations.AssociateUcrSummaryController.submit()
+
+# Associate UCR confirmation page
+GET         /associate-ucr-confirmation           controllers.consolidations.AssociateUcrConfirmationController.display()
 
 # Disassociate UCR page
 GET         /disassociate-ucr                     controllers.consolidations.DisassociateUcrController.display()
@@ -30,33 +33,33 @@ POST        /disassociate-ucr-summary             controllers.consolidations.Dis
 GET         /disassociate-ucr-confirmation        controllers.consolidations.DisassociateUcrConfirmationController.display()
 
 # Enter DUCR page
-GET         /consignment-references                controllers.movements.ConsignmentReferencesController.displayPage()
-POST        /consignment-references                controllers.movements.ConsignmentReferencesController.saveConsignmentReferences()
+GET         /consignment-references               controllers.movements.ConsignmentReferencesController.displayPage()
+POST        /consignment-references               controllers.movements.ConsignmentReferencesController.saveConsignmentReferences()
 
 # Arrival Reference page
-GET         /arrival-reference                     controllers.movements.ArrivalReferenceController.displayPage()
-POST        /arrival-reference                     controllers.movements.ArrivalReferenceController.submit()
+GET         /arrival-reference                    controllers.movements.ArrivalReferenceController.displayPage()
+POST        /arrival-reference                    controllers.movements.ArrivalReferenceController.submit()
 
 # Movement details page
-GET         /movement-details                      controllers.movements.MovementDetailsController.displayPage()
-POST        /movement-details                      controllers.movements.MovementDetailsController.saveMovementDetails()
+GET         /movement-details                     controllers.movements.MovementDetailsController.displayPage()
+POST        /movement-details                     controllers.movements.MovementDetailsController.saveMovementDetails()
 
 # Goods location page
-GET         /location                              controllers.movements.LocationController.displayPage()
-POST        /location                              controllers.movements.LocationController.saveLocation()
+GET         /location                             controllers.movements.LocationController.displayPage()
+POST        /location                             controllers.movements.LocationController.saveLocation()
 
 # Transport page
-GET         /transport                             controllers.movements.TransportController.displayPage()
-POST        /transport                             controllers.movements.TransportController.saveTransport()
+GET         /transport                            controllers.movements.TransportController.displayPage()
+POST        /transport                            controllers.movements.TransportController.saveTransport()
 
 # Summary
-GET         /summary                               controllers.movements.SummaryController.displayPage()
-POST        /summary                               controllers.movements.SummaryController.submitMovementRequest()
+GET         /summary                              controllers.movements.SummaryController.displayPage()
+POST        /summary                              controllers.movements.SummaryController.submitMovementRequest()
 
 # Shut a MUCR
-GET         /shut-mucr                             controllers.consolidations.ShutMucrController.displayPage()
-POST        /shut-mucr                             controllers.consolidations.ShutMucrController.submit()
+GET         /shut-mucr                            controllers.consolidations.ShutMucrController.displayPage()
+POST        /shut-mucr                            controllers.consolidations.ShutMucrController.submit()
 
 # Shut a MUCR summary page
-GET         /shut-mucr-summary                     controllers.consolidations.ShutMucrSummaryController.displayPage()
-POST        /shut-mucr-summary                     controllers.consolidations.ShutMucrSummaryController.submit()
+GET         /shut-mucr-summary                    controllers.consolidations.ShutMucrSummaryController.displayPage()
+POST        /shut-mucr-summary                    controllers.consolidations.ShutMucrSummaryController.submit()

--- a/test/controllers/consolidations/AssociateUcrConfirmationControllerSpec.scala
+++ b/test/controllers/consolidations/AssociateUcrConfirmationControllerSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.consolidations
+
+import controllers.ControllerLayerSpec
+import controllers.actions.AuthenticatedAction
+import controllers.storage.FlashKeys
+import play.api.http.Status
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import views.html.associate_ucr_confirmation
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AssociateUcrConfirmationControllerSpec extends ControllerLayerSpec {
+
+  private val page = new associate_ucr_confirmation(main_template)
+
+  private def controller(auth: AuthenticatedAction) =
+    new AssociateUcrConfirmationController(auth, stubMessagesControllerComponents(), page)
+
+  "GET" should {
+    implicit val get = FakeRequest("GET", "/").withFlash((FlashKeys.CONSOLIDATION_KIND, "kind"), (FlashKeys.UCR, "ucr"))
+
+    "return 200 when authenticated" in {
+      val result = controller(SuccessfulAuth()).display(get)
+
+      status(result) mustBe Status.OK
+      contentAsHtml(result) mustBe page("kind", "ucr")
+    }
+
+    "return 403 when unauthenticated" in {
+      val result = controller(UnsuccessfulAuth).display(get)
+
+      status(result) mustBe Status.FORBIDDEN
+    }
+  }
+}

--- a/test/controllers/consolidations/AssociateUcrControllerSpec.scala
+++ b/test/controllers/consolidations/AssociateUcrControllerSpec.scala
@@ -31,12 +31,12 @@ import views.html.associate_ucr
 
 import scala.concurrent.ExecutionContext.global
 
-class AssociateUCRControllerSpec extends ControllerLayerSpec with MockCache {
+class AssociateUcrControllerSpec extends ControllerLayerSpec with MockCache {
 
   val associateUcrPage = mock[associate_ucr]
 
   def controller(associateUcrAnswers: AssociateUcrAnswers) =
-    new AssociateUCRController(SuccessfulAuth(), ValidJourney(associateUcrAnswers), stubMessagesControllerComponents(), cache, associateUcrPage)(
+    new AssociateUcrController(SuccessfulAuth(), ValidJourney(associateUcrAnswers), stubMessagesControllerComponents(), cache, associateUcrPage)(
       global
     )
 

--- a/test/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
+++ b/test/controllers/consolidations/AssociateUcrSummaryControllerSpec.scala
@@ -26,36 +26,33 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.SubmissionService
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
-import views.html.{associate_ucr_confirmation, associate_ucr_summary}
+import views.html.associate_ucr_summary
 
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.Future
 
-class AssociateUCRSummaryControllerSpec extends ControllerLayerSpec {
+class AssociateUcrSummaryControllerSpec extends ControllerLayerSpec {
 
   private val summaryPage = mock[associate_ucr_summary]
-  private val confirmPage = mock[associate_ucr_confirmation]
   private val submissionService = mock[SubmissionService]
 
   private def controller(associateUcrAnswers: AssociateUcrAnswers) =
-    new AssociateUCRSummaryController(
+    new AssociateUcrSummaryController(
       SuccessfulAuth(),
       ValidJourney(associateUcrAnswers),
       stubMessagesControllerComponents(),
       submissionService,
-      summaryPage,
-      confirmPage
+      summaryPage
     )(global)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
 
     when(summaryPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
-    when(confirmPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override protected def afterEach(): Unit = {
-    reset(summaryPage, confirmPage)
+    reset(summaryPage)
 
     super.afterEach()
   }
@@ -73,6 +70,9 @@ class AssociateUCRSummaryControllerSpec extends ControllerLayerSpec {
         status(result) mustBe OK
         verify(summaryPage).apply(any(), any())(any(), any())
       }
+    }
+
+    "return 303 (SEE_OTHER)" when {
 
       "submission finished with success" in {
 
@@ -83,8 +83,7 @@ class AssociateUCRSummaryControllerSpec extends ControllerLayerSpec {
 
         val result = controller(cachedData).submit()(postRequest)
 
-        status(result) mustBe OK
-        verify(confirmPage).apply(any(), any())(any(), any())
+        status(result) mustBe SEE_OTHER
       }
     }
 

--- a/test/controllers/consolidations/MucrOptionsControllerSpec.scala
+++ b/test/controllers/consolidations/MucrOptionsControllerSpec.scala
@@ -107,7 +107,7 @@ class MucrOptionsControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit()(postRequest(correctForm))
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(controllers.consolidations.routes.AssociateUCRController.displayPage().url)
+        redirectLocation(result) mustBe Some(controllers.consolidations.routes.AssociateUcrController.displayPage().url)
       }
     }
   }

--- a/test/views/consolidations/AssociateUcrSummaryViewSpec.scala
+++ b/test/views/consolidations/AssociateUcrSummaryViewSpec.scala
@@ -23,7 +23,7 @@ import play.api.test.FakeRequest
 import play.twirl.api.Html
 import views.ViewSpec
 
-class AssociateUCRSummaryViewSpec extends ViewSpec {
+class AssociateUcrSummaryViewSpec extends ViewSpec {
 
   implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
   private val page = new views.html.associate_ucr_summary(main_template)
@@ -41,7 +41,7 @@ class AssociateUCRSummaryViewSpec extends ViewSpec {
 
     "display 'Change' link on page for associate ucr" in {
       view.getElementById("associate_ducr-change") must containText(messages("site.change"))
-      view.getElementById("associate_ducr-change") must haveHref(controllers.consolidations.routes.AssociateUCRController.displayPage())
+      view.getElementById("associate_ducr-change") must haveHref(controllers.consolidations.routes.AssociateUcrController.displayPage())
     }
 
     "display 'Change' link on the page for mucr" in {


### PR DESCRIPTION
This is a POC PR for the AssociateUcr journey.   Looks like more changes than there are really as I've also renamed the 2 existing controllers.  The important bits are

- AssociateUcrConfirmationController which attempts to extract the confirmation data from Flash, redirecting to Choice page if it fails (i.e. user has refreshed confirmation page)

- AssociateUcrSummaryController which now redirects to AssociateUcrConfirmationController after submission (rather than rendering the confirmation screen)