### PR TITLE
CEDS-1940 Fix Confirmation POST/Redirect/GET logic

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -54,7 +54,7 @@ class ChoiceController @Inject()(
       case forms.Choice.AssociateUCR =>
         proceedJourney(AssociateUcrAnswers(), consolidations.routes.MucrOptionsController.displayPage())
       case forms.Choice.DisassociateUCR =>
-        proceedJourney(DisassociateUcrAnswers(), consolidations.routes.DisassociateUcrController.display())
+        proceedJourney(DisassociateUcrAnswers(), consolidations.routes.DisassociateUCRController.display())
       case forms.Choice.ShutMUCR =>
         proceedJourney(AssociateUcrAnswers(), consolidations.routes.ShutMucrController.displayPage())
       case forms.Choice.ViewSubmissions =>
@@ -75,7 +75,7 @@ class ChoiceController @Inject()(
           case forms.Choice.AssociateUCR =>
             proceedJourney(AssociateUcrAnswers(), consolidations.routes.MucrOptionsController.displayPage())
           case forms.Choice.DisassociateUCR =>
-            proceedJourney(DisassociateUcrAnswers(), consolidations.routes.DisassociateUcrController.display())
+            proceedJourney(DisassociateUcrAnswers(), consolidations.routes.DisassociateUCRController.display())
           case forms.Choice.ShutMUCR =>
             proceedJourney(ShutMucrAnswers(), consolidations.routes.ShutMucrController.displayPage())
           case forms.Choice.ViewSubmissions =>

--- a/app/controllers/consolidations/AssociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/AssociateUCRConfirmationController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.consolidations
+
+import controllers.actions.AuthenticatedAction
+import controllers.storage.FlashKeys
+import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.associate_ucr_confirmation
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class AssociateUCRConfirmationController @Inject()(
+  authenticate: AuthenticatedAction,
+  mcc: MessagesControllerComponents,
+  page: associate_ucr_confirmation
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport {
+
+  def display: Action[AnyContent] = authenticate { implicit request =>
+    val flash = implicitly[Flash]
+    val kind = flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
+    val ucr = flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    Ok(page(kind, ucr))
+  }
+
+}

--- a/app/controllers/consolidations/AssociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/AssociateUCRConfirmationController.scala
@@ -36,9 +36,8 @@ class AssociateUCRConfirmationController @Inject()(
     extends FrontendController(mcc) with I18nSupport {
 
   def display: Action[AnyContent] = authenticate { implicit request =>
-    val flash = implicitly[Flash]
-    val kind = flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
-    val ucr = flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    val kind = request.flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
+    val ucr = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
     Ok(page(kind, ucr))
   }
 

--- a/app/controllers/consolidations/AssociateUCRSummaryController.scala
+++ b/app/controllers/consolidations/AssociateUCRSummaryController.scala
@@ -25,6 +25,8 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.SubmissionService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.{associate_ucr_confirmation, associate_ucr_summary}
+import play.api.mvc.Results.Redirect
+import controllers.storage.FlashKeys
 
 import scala.concurrent.ExecutionContext
 
@@ -33,8 +35,7 @@ class AssociateUCRSummaryController @Inject()(
   getJourney: JourneyRefiner,
   mcc: MessagesControllerComponents,
   submissionService: SubmissionService,
-  associateUcrSummaryPage: associate_ucr_summary,
-  associateUCRConfirmPage: associate_ucr_confirmation
+  associateUcrSummaryPage: associate_ucr_summary
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
@@ -54,7 +55,8 @@ class AssociateUCRSummaryController @Inject()(
     val associateUcr = answers.associateUcr.getOrElse(throw ReturnToStartException)
 
     submissionService.submit(request.providerId, answers).map { _ =>
-      Ok(associateUCRConfirmPage(associateUcr.kind.formValue, associateUcr.ucr))
+      Redirect(controllers.consolidations.routes.AssociateUCRConfirmationController.display())
+        .flashing(FlashKeys.CONSOLIDATION_KIND -> associateUcr.kind.formValue, FlashKeys.UCR -> associateUcr.ucr)
     }
   }
 }

--- a/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
@@ -26,7 +26,7 @@ import views.html.disassociate_ucr_confirmation
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class DisassociateUcrConfirmationController @Inject()(
+class DisassociateUCRConfirmationController @Inject()(
   authenticate: AuthenticatedAction,
   mcc: MessagesControllerComponents,
   page: disassociate_ucr_confirmation

--- a/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
@@ -17,7 +17,9 @@
 package controllers.consolidations
 
 import controllers.actions.AuthenticatedAction
+import controllers.storage.FlashKeys
 import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -34,7 +36,9 @@ class DisassociateUCRConfirmationController @Inject()(
     extends FrontendController(mcc) with I18nSupport {
 
   def display: Action[AnyContent] = authenticate { implicit request =>
-    Ok(page())
+    val kind = request.flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
+    val ucr = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    Ok(page(kind, ucr))
   }
 
 }

--- a/app/controllers/consolidations/ShutMUCRConfirmationController.scala
+++ b/app/controllers/consolidations/ShutMUCRConfirmationController.scala
@@ -28,12 +28,9 @@ import views.html.shut_mucr_confirmation
 import scala.concurrent.ExecutionContext
 
 @Singleton
-class ShutMUCRConfirmationController @Inject()(
-  authenticate: AuthenticatedAction,
-  mcc: MessagesControllerComponents,
-  page: shut_mucr_confirmation
-)(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
+class ShutMUCRConfirmationController @Inject()(authenticate: AuthenticatedAction, mcc: MessagesControllerComponents, page: shut_mucr_confirmation)(
+  implicit ec: ExecutionContext
+) extends FrontendController(mcc) with I18nSupport {
 
   def display: Action[AnyContent] = authenticate { implicit request =>
     val ucr = request.flash.get(FlashKeys.MUCR).getOrElse(throw ReturnToStartException)

--- a/app/controllers/movements/MovementConfirmationController.scala
+++ b/app/controllers/movements/MovementConfirmationController.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.movements
+
+import controllers.actions.AuthenticatedAction
+import controllers.storage.FlashKeys
+import forms.ConsignmentReferences
+import javax.inject.{Inject, Singleton}
+import models.ReturnToStartException
+import models.cache.JourneyType
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.movement_confirmation_page
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class MovementConfirmationController @Inject()(authenticate: AuthenticatedAction, mcc: MessagesControllerComponents, page: movement_confirmation_page)(
+  implicit ec: ExecutionContext
+) extends FrontendController(mcc) with I18nSupport {
+
+  def display: Action[AnyContent] = authenticate { implicit request =>
+    val flash = implicitly[Flash]
+    val `type` = flash.get(FlashKeys.MOVEMENT_TYPE).map(JourneyType.withName).getOrElse(throw ReturnToStartException)
+    val kind = flash.get(FlashKeys.UCR_KIND).getOrElse(throw ReturnToStartException)
+    val reference = flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    Ok(page(`type`, ConsignmentReferences(kind, reference)))
+  }
+
+}

--- a/app/controllers/movements/MovementConfirmationController.scala
+++ b/app/controllers/movements/MovementConfirmationController.scala
@@ -35,10 +35,9 @@ class MovementConfirmationController @Inject()(authenticate: AuthenticatedAction
 ) extends FrontendController(mcc) with I18nSupport {
 
   def display: Action[AnyContent] = authenticate { implicit request =>
-    val flash = implicitly[Flash]
-    val `type` = flash.get(FlashKeys.MOVEMENT_TYPE).map(JourneyType.withName).getOrElse(throw ReturnToStartException)
-    val kind = flash.get(FlashKeys.UCR_KIND).getOrElse(throw ReturnToStartException)
-    val reference = flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
+    val `type` = request.flash.get(FlashKeys.MOVEMENT_TYPE).map(JourneyType.withName).getOrElse(throw ReturnToStartException)
+    val kind = request.flash.get(FlashKeys.UCR_KIND).getOrElse(throw ReturnToStartException)
+    val reference = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
     Ok(page(`type`, ConsignmentReferences(kind, reference)))
   }
 

--- a/app/controllers/storage/FlashKeys.scala
+++ b/app/controllers/storage/FlashKeys.scala
@@ -17,7 +17,9 @@
 package controllers.storage
 
 object FlashKeys {
+  val MOVEMENT_TYPE: String = "MOVEMENT_TYPE"
   val UCR = "UCR"
+  val UCR_KIND = "UCR_KIND"
   val CONSOLIDATION_KIND = "CONSOLIDATION_KIND"
   val MUCR = "MUCR"
 }

--- a/app/views/disassociate_ucr.scala.html
+++ b/app/views/disassociate_ucr.scala.html
@@ -25,7 +25,7 @@
 @(form: Form[DisassociateUcr])(implicit request: Request[_], messages: Messages)
 
     @main_template(title = Title("disassociate.ucr.title", None)) {
-        @helper.form(controllers.consolidations.routes.DisassociateUcrController.submit(), 'autoComplete -> "off") {
+        @helper.form(controllers.consolidations.routes.DisassociateUCRController.submit(), 'autoComplete -> "off") {
             @helper.CSRF.formField
 
             @components.back_link(routes.ChoiceController.displayPage())

--- a/app/views/disassociate_ucr_confirmation.scala.html
+++ b/app/views/disassociate_ucr_confirmation.scala.html
@@ -15,22 +15,20 @@
  *@
 
 @import controllers.routes
-@import controllers.storage.FlashKeys
 @import views.Title
 @import views.html.templates.main_template
 
 @this(main_template: main_template)
 
-@()(implicit request: Request[_], flash: Flash, messages: Messages)
+@(kind: String, ucr: String)(implicit request: Request[_], messages: Messages)
 
     @associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR)">@messages("disassociation.confirmation.associateOrShut.associate")</a>}
     @shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR)">@messages("disassociation.confirmation.associateOrShut.shut")</a>}
-    @kind = @{flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse("")}
 
     @main_template(title = Title(messages("disassociate.ucr.confirmation.tab.heading", kind))) {
 
         @components.highlight_box_with_reference(
-            headingText = messages("disassociate.ucr.confirmation.heading", kind, flash.get(FlashKeys.UCR).getOrElse("-"))
+            headingText = messages("disassociate.ucr.confirmation.heading", kind, ucr)
         )
 
         @components.confirmation_status_info()

--- a/app/views/disassociate_ucr_summary.scala.html
+++ b/app/views/disassociate_ucr_summary.scala.html
@@ -23,10 +23,10 @@
 @(disassociateUcr: DisassociateUcr)(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Title(messages("disassociate.ucr.summary.title")), fullWidth = true) {
-    @helper.form(consolidations.routes.DisassociateUcrSummaryController.submit(), 'autoComplete -> "off") {
+    @helper.form(consolidations.routes.DisassociateUCRSummaryController.submit(), 'autoComplete -> "off") {
       @helper.CSRF.formField
 
-      @components.back_link(consolidations.routes.DisassociateUcrController.display())
+      @components.back_link(consolidations.routes.DisassociateUCRController.display())
 
       @components.page_title(title = Some(messages("disassociate.ucr.summary.title")))
 
@@ -37,7 +37,7 @@
                   <td id="disassociate_ucr-type">@disassociateUcr.kind.toString.toUpperCase</td>
                   <td id="disassociate_ucr-reference">@disassociateUcr.ucr</td>
                   <td class="text-right">
-                      <a id="disassociate_ucr-remove" href="@consolidations.routes.DisassociateUcrController.display()">@messages("site.change")</a>
+                      <a id="disassociate_ucr-remove" href="@consolidations.routes.DisassociateUCRController.display()">@messages("site.change")</a>
                   </td>
               </tr>
           </tbody>

--- a/app/views/movement_confirmation_page.scala.html
+++ b/app/views/movement_confirmation_page.scala.html
@@ -14,15 +14,15 @@
  * limitations under the License.
  *@
 
-@import controllers.exchanges.JourneyRequest
 @import views.html.templates.main_template
 @import models.cache.JourneyType
+@import models.cache.JourneyType.JourneyType
 @import views.Title
 @import forms.ConsignmentReferences
 
 @this(main_template: main_template)
 
-@(consignmentReferences: ConsignmentReferences)(implicit request: JourneyRequest[_], messages: Messages)
+@(journeyType: JourneyType, consignmentReferences: ConsignmentReferences)(implicit request: Request[_], messages: Messages)
 
 
 @associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR)">@messages("movement.arrival.confirmation.nextSteps.associate")</a>}
@@ -31,12 +31,12 @@
 @arrivalLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Arrival)">@messages("movement.departure.confirmation.nextSteps.arrive")</a>}
 
 @main_template(
-    title = Title(s"movement.${request.answers.`type`}.confirmation.tab.heading", None)
+    title = Title(s"movement.${journeyType}.confirmation.tab.heading", None)
 ) {
 
     @components.highlight_box_with_reference(
         headingText = messages(
-            s"movement.${request.answers.`type`}.confirmation.heading",
+            s"movement.${journeyType}.confirmation.heading",
             if(consignmentReferences.reference == "D") "DUCR" else "MUCR",
             consignmentReferences.referenceValue
         )
@@ -46,12 +46,12 @@
 
     <h2 id="what-next">@messages("movement.confirmation.whatNext")</h2>
 
-    @if(request.answers.`type` == JourneyType.ARRIVE) {
+    @if(journeyType == JourneyType.ARRIVE) {
         <div id="next-steps">
             @Html(messages("movement.arrival.confirmation.nextSteps", associateLink, departureLinkForArrival))
         </div>
     }
-    @if(request.answers.`type` == JourneyType.DEPART) {
+    @if(journeyType == JourneyType.DEPART) {
         <div id="next-steps">
             @Html(messages("movement.departure.confirmation.nextSteps", departureLinkForDeparture, arrivalLink))
         </div>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -56,6 +56,9 @@ POST        /transport                             controllers.movements.Transpo
 GET         /summary                               controllers.movements.SummaryController.displayPage()
 POST        /summary                               controllers.movements.SummaryController.submitMovementRequest()
 
+# Movement confirmation page
+GET         /movement-confirmation                 controllers.movements.MovementConfirmationController.display()
+
 # Shut a MUCR
 GET         /shut-mucr                             controllers.consolidations.ShutMucrController.displayPage()
 POST        /shut-mucr                             controllers.consolidations.ShutMucrController.submit()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -67,6 +67,9 @@ POST        /shut-mucr                             controllers.consolidations.Sh
 GET         /shut-mucr-summary                     controllers.consolidations.ShutMucrSummaryController.displayPage()
 POST        /shut-mucr-summary                     controllers.consolidations.ShutMucrSummaryController.submit()
 
+# Shut a MUCR confirmation page
+GET         /shut-mucr-confirmation                 controllers.consolidations.ShutMUCRConfirmationController.display()
+
 # Submissions page
 GET         /submissions                           controllers.ViewSubmissionsController.displayPage()
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -18,16 +18,19 @@ POST        /associate-ucr                         controllers.consolidations.As
 GET         /associate-ucr-summary                 controllers.consolidations.AssociateUCRSummaryController.displayPage()
 POST        /associate-ucr-summary                 controllers.consolidations.AssociateUCRSummaryController.submit()
 
+# Associate UCR confirmation page
+GET         /associate-ucr-confirmation            controllers.consolidations.AssociateUCRConfirmationController.display()
+
 # Disassociate UCR page
-GET         /dissociate-ucr                     controllers.consolidations.DisassociateUcrController.display()
-POST        /dissociate-ucr                     controllers.consolidations.DisassociateUcrController.submit()
+GET         /dissociate-ucr                        controllers.consolidations.DisassociateUCRController.display()
+POST        /dissociate-ucr                        controllers.consolidations.DisassociateUCRController.submit()
 
 # Disassociate UCR summary page
-GET         /dissociate-ucr-summary             controllers.consolidations.DisassociateUcrSummaryController.display()
-POST        /dissociate-ucr-summary             controllers.consolidations.DisassociateUcrSummaryController.submit()
+GET         /dissociate-ucr-summary                controllers.consolidations.DisassociateUCRSummaryController.display()
+POST        /dissociate-ucr-summary                controllers.consolidations.DisassociateUCRSummaryController.submit()
 
 # Disassociate UCR confirmation page
-GET         /dissociate-ucr-confirmation        controllers.consolidations.DisassociateUcrConfirmationController.display()
+GET         /dissociate-ucr-confirmation           controllers.consolidations.DisassociateUCRConfirmationController.display()
 
 # Enter DUCR page
 GET         /consignment-references                controllers.movements.ConsignmentReferencesController.displayPage()

--- a/test/controllers/ChoiceControllerSpec.scala
+++ b/test/controllers/ChoiceControllerSpec.scala
@@ -122,7 +122,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().startSpecificJourney(Choice.DisassociateUCR)(getRequest)
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(consolidationRoutes.DisassociateUcrController.display().url)
+        redirectLocation(result) mustBe Some(consolidationRoutes.DisassociateUCRController.display().url)
       }
 
       "user chooses shut mucr" in {
@@ -181,7 +181,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit(postWithChoice(DisassociateUCR))
 
         status(result) mustBe SEE_OTHER
-        redirectLocation(result) mustBe Some(consolidationRoutes.DisassociateUcrController.display().url)
+        redirectLocation(result) mustBe Some(consolidationRoutes.DisassociateUCRController.display().url)
         theCacheUpserted mustBe Cache(providerId, DisassociateUcrAnswers())
       }
 

--- a/test/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
+++ b/test/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
@@ -17,6 +17,7 @@
 package controllers.consolidations
 
 import controllers.ControllerLayerSpec
+import controllers.storage.FlashKeys
 import forms.{AssociateKind, AssociateUcr, MucrOptions}
 import models.ReturnToStartException
 import models.cache.AssociateUcrAnswers
@@ -26,7 +27,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.SubmissionService
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
-import views.html.{associate_ucr_confirmation, associate_ucr_summary}
+import views.html.associate_ucr_summary
 
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.Future
@@ -34,7 +35,6 @@ import scala.concurrent.Future
 class AssociateUCRSummaryControllerSpec extends ControllerLayerSpec {
 
   private val summaryPage = mock[associate_ucr_summary]
-  private val confirmPage = mock[associate_ucr_confirmation]
   private val submissionService = mock[SubmissionService]
 
   private def controller(associateUcrAnswers: AssociateUcrAnswers) =
@@ -43,78 +43,75 @@ class AssociateUCRSummaryControllerSpec extends ControllerLayerSpec {
       ValidJourney(associateUcrAnswers),
       stubMessagesControllerComponents(),
       submissionService,
-      summaryPage,
-      confirmPage
+      summaryPage
     )(global)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
 
     when(summaryPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
-    when(confirmPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override protected def afterEach(): Unit = {
-    reset(summaryPage, confirmPage)
+    reset(summaryPage)
 
     super.afterEach()
   }
 
-  "Associate UCR Summary Controller" should {
+  "GET" should {
+    "return 200 (OK)" in {
 
-    "return 200 (OK)" when {
+      val answers = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")), associateUcr = Some(AssociateUcr(AssociateKind.Ducr, "123")))
 
-      "displayPage is invoked with mucr and ucr in cache" in {
+      val result = controller(answers).displayPage()(getRequest)
 
-        val cachedData = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")), associateUcr = Some(AssociateUcr(AssociateKind.Ducr, "123")))
-
-        val result = controller(cachedData).displayPage()(getRequest)
-
-        status(result) mustBe OK
-        verify(summaryPage).apply(any(), any())(any(), any())
-      }
-
-      "submission finished with success" in {
-
-        when(submissionService.submit(any(), any[AssociateUcrAnswers])(any()))
-          .thenReturn(Future.successful((): Unit))
-
-        val cachedData = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")), associateUcr = Some(AssociateUcr(AssociateKind.Ducr, "123")))
-
-        val result = controller(cachedData).submit()(postRequest)
-
-        status(result) mustBe OK
-        verify(confirmPage).apply(any(), any())(any(), any())
-      }
+      status(result) mustBe OK
+      verify(summaryPage).apply(any(), any())(any(), any())
     }
 
     "throw an exception" when {
 
-      "mucr is missing during displayPage" in {
+      "mucr is missing" in {
+        val answers = AssociateUcrAnswers(associateUcr = Some(AssociateUcr(AssociateKind.Ducr, "123")))
 
-        val cachedData = AssociateUcrAnswers(associateUcr = Some(AssociateUcr(AssociateKind.Ducr, "123")))
-
-        intercept[ReturnToStartException.type] {
-          await(controller(cachedData).displayPage()(getRequest))
-        }
+        intercept[RuntimeException] {
+          await(controller(answers).displayPage()(getRequest))
+        } mustBe ReturnToStartException
       }
 
-      "ucr is missing during displayPage" in {
+      "ucr is missing" in {
+        val answers = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")))
 
-        val cachedData = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")))
-
-        intercept[ReturnToStartException.type] {
-          await(controller(cachedData).displayPage()(getRequest))
-        }
+        intercept[RuntimeException] {
+          await(controller(answers).displayPage()(getRequest))
+        } mustBe ReturnToStartException
       }
 
-      "associate ucr is empty during submission" in {
 
+    }
+  }
+
+  "POST" should {
+    "redirect to confirmation" in {
+      when(submissionService.submit(any(), any[AssociateUcrAnswers])(any())).thenReturn(Future.successful((): Unit))
+
+      val cachedData = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")), associateUcr = Some(AssociateUcr(AssociateKind.Ducr, "123")))
+
+      val result = controller(cachedData).submit()(postRequest)
+
+      status(result) mustBe SEE_OTHER
+      redirectLocation(result) mustBe Some(controllers.consolidations.routes.AssociateUCRConfirmationController.display().url)
+      flash(result).get(FlashKeys.CONSOLIDATION_KIND) mustBe Some("ducr")
+      flash(result).get(FlashKeys.UCR) mustBe Some("123")
+    }
+
+    "return to start" when {
+      "ucr is missing" in {
         val cachedData = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")))
 
-        intercept[ReturnToStartException.type] {
+        intercept[RuntimeException] {
           await(controller(cachedData).submit()(postRequest))
-        }
+        } mustBe ReturnToStartException
       }
     }
   }

--- a/test/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
+++ b/test/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
@@ -87,7 +87,6 @@ class AssociateUCRSummaryControllerSpec extends ControllerLayerSpec {
         } mustBe ReturnToStartException
       }
 
-
     }
   }
 

--- a/test/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
+++ b/test/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.consolidations
+
+import controllers.ControllerLayerSpec
+import controllers.actions.AuthenticatedAction
+import play.api.http.Status
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import views.html.disassociate_ucr_confirmation
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class DisassociateUCRConfirmationControllerSpec extends ControllerLayerSpec {
+
+  private val page = new disassociate_ucr_confirmation(main_template)
+
+  private def controller(auth: AuthenticatedAction) =
+    new DisassociateUCRConfirmationController(auth, stubMessagesControllerComponents(), page)
+
+  "GET" should {
+    implicit val get = FakeRequest("GET", "/")
+
+    "return 200 when authenticated" in {
+      val result = controller(SuccessfulAuth()).display(get)
+
+      status(result) mustBe Status.OK
+      contentAsHtml(result) mustBe page()
+    }
+
+    "return 403 when unauthenticated" in {
+      val result = controller(UnsuccessfulAuth).display(get)
+
+      status(result) mustBe Status.FORBIDDEN
+    }
+  }
+}

--- a/test/controllers/consolidations/DisassociateUCRControllerSpec.scala
+++ b/test/controllers/consolidations/DisassociateUCRControllerSpec.scala
@@ -19,50 +19,42 @@ package controllers.consolidations
 import base.MockCache
 import controllers.ControllerLayerSpec
 import controllers.actions.AuthenticatedAction
-import controllers.storage.FlashKeys
 import forms.{DisassociateKind, DisassociateUcr}
-import models.ReturnToStartException
-import models.cache.{Answers, Cache, DisassociateUcrAnswers}
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers._
-import org.mockito.BDDMockito._
-import org.mockito.Mockito.verify
+import models.cache.{Answers, DisassociateUcrAnswers}
 import play.api.http.Status
+import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.SubmissionService
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
-import views.html.disassociate_ucr_summary
+import views.html.disassociate_ucr
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
-class DisassociateUcrSummaryControllerSpec extends ControllerLayerSpec with MockCache {
+class DisassociateUCRControllerSpec extends ControllerLayerSpec with MockCache {
 
   private val ucr = "9AB123456"
   private val disassociation = DisassociateUcr(DisassociateKind.Ducr, Some(ucr), None)
-  private val answers = DisassociateUcrAnswers(Answers.fakeEORI, Some(DisassociateUcr(DisassociateKind.Ducr, Some(ucr), None)))
-  private val submissionService = mock[SubmissionService]
-  private val page = new disassociate_ucr_summary(main_template)
+  private val page = new disassociate_ucr(main_template)
 
   private def controller(auth: AuthenticatedAction, existingAnswers: Answers) =
-    new DisassociateUcrSummaryController(auth, ValidJourney(existingAnswers), stubMessagesControllerComponents(), submissionService, cache, page)
+    new DisassociateUCRController(auth, ValidJourney(existingAnswers), stubMessagesControllerComponents(), cache, page)
 
   "GET" should {
     implicit val get = FakeRequest("GET", "/").withCSRFToken
 
     "return 200 when authenticated" when {
       "empty page answers" in {
-        intercept[Throwable] {
-          await(controller(SuccessfulAuth(), DisassociateUcrAnswers(ucr = None)).display(get))
-        } mustBe ReturnToStartException
+        val result = controller(SuccessfulAuth(), DisassociateUcrAnswers(ucr = None)).display(get)
+
+        status(result) mustBe Status.OK
+        contentAsHtml(result) mustBe page(DisassociateUcr.form)
       }
 
       "existing page answers" in {
-        val result = controller(SuccessfulAuth(), answers).display(get)
+        val result = controller(SuccessfulAuth(), DisassociateUcrAnswers(ucr = Some(disassociation))).display(get)
 
         status(result) mustBe Status.OK
-        contentAsHtml(result) mustBe page(disassociation)
+        contentAsHtml(result) mustBe page(DisassociateUcr.form.fill(disassociation))
       }
     }
 
@@ -75,22 +67,21 @@ class DisassociateUcrSummaryControllerSpec extends ControllerLayerSpec with Mock
 
   "POST" should {
     "return 200 when authenticated" in {
-      given(submissionService.submit(anyString(), any[DisassociateUcrAnswers]())(any())).willReturn(Future.successful((): Unit))
-
-      val post = FakeRequest("POST", "/").withCSRFToken
-      val result = controller(SuccessfulAuth(), answers).submit(post)
+      val post = FakeRequest("POST", "/").withJsonBody(Json.toJson(disassociation)).withCSRFToken
+      val result = controller(SuccessfulAuth(), DisassociateUcrAnswers()).submit(post)
 
       status(result) mustBe Status.SEE_OTHER
-      redirectLocation(result) mustBe Some(routes.DisassociateUcrConfirmationController.display().url)
-      flash(result).get(FlashKeys.UCR) mustBe Some(ucr)
-      flash(result).get(FlashKeys.CONSOLIDATION_KIND) mustBe Some(DisassociateKind.Ducr.toString)
-      theSubmission mustBe answers
+      redirectLocation(result) mustBe Some(routes.DisassociateUCRSummaryController.display().url)
+      theCacheUpserted.answers mustBe DisassociateUcrAnswers(ucr = Some(disassociation))
     }
 
-    def theSubmission: DisassociateUcrAnswers = {
-      val captor: ArgumentCaptor[DisassociateUcrAnswers] = ArgumentCaptor.forClass(classOf[DisassociateUcrAnswers])
-      verify(submissionService).submit(anyString(), captor.capture())(any())
-      captor.getValue
+    "return 400 when invalid" in {
+      implicit val post = FakeRequest("POST", "/").withCSRFToken
+
+      val result = controller(SuccessfulAuth(), DisassociateUcrAnswers()).submit(post)
+
+      status(result) mustBe Status.BAD_REQUEST
+      contentAsHtml(result) mustBe page(DisassociateUcr.form.bind(Map[String, String]()))
     }
 
     "return 403 when unauthenticated" in {

--- a/test/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
+++ b/test/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.consolidations
+
+import controllers.ControllerLayerSpec
+import controllers.actions.AuthenticatedAction
+import controllers.storage.FlashKeys
+import models.ReturnToStartException
+import play.api.http.Status
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import views.html.shut_mucr_confirmation
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class ShutMUCRConfirmationControllerSpec extends ControllerLayerSpec {
+
+  private val page = new shut_mucr_confirmation(main_template)
+
+  private def controller(auth: AuthenticatedAction) =
+    new ShutMUCRConfirmationController(auth, stubMessagesControllerComponents(), page)
+
+  "GET" should {
+    implicit val get = FakeRequest("GET", "/")
+
+    "return 200 when authenticated" in {
+      val result = controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MUCR -> "123"))
+
+      status(result) mustBe Status.OK
+      contentAsHtml(result) mustBe page("123")
+    }
+
+    "return to start for missing params" in {
+      intercept[RuntimeException] {
+        await(controller(SuccessfulAuth()).display(get))
+      } mustBe ReturnToStartException
+    }
+
+    "return 403 when unauthenticated" in {
+      val result = controller(UnsuccessfulAuth).display(get)
+
+      status(result) mustBe Status.FORBIDDEN
+    }
+  }
+}

--- a/test/controllers/consolidations/ShutMucrSummaryControllerSpec.scala
+++ b/test/controllers/consolidations/ShutMucrSummaryControllerSpec.scala
@@ -39,13 +39,7 @@ class ShutMucrSummaryControllerSpec extends ControllerLayerSpec with MockCache {
   private val submissionService = mock[SubmissionService]
 
   private def controller(answers: Answers = ShutMucrAnswers()) =
-    new ShutMucrSummaryController(
-      SuccessfulAuth(),
-      ValidJourney(answers),
-      stubMessagesControllerComponents(),
-      submissionService,
-      summaryPage
-    )(global)
+    new ShutMucrSummaryController(SuccessfulAuth(), ValidJourney(answers), stubMessagesControllerComponents(), submissionService, summaryPage)(global)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/controllers/movements/MovementConfirmationControllerSpec.scala
+++ b/test/controllers/movements/MovementConfirmationControllerSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.movements
+
+import controllers.ControllerLayerSpec
+import controllers.actions.AuthenticatedAction
+import controllers.storage.FlashKeys
+import forms.ConsignmentReferences
+import models.ReturnToStartException
+import models.cache.JourneyType
+import play.api.http.Status
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import views.html.movement_confirmation_page
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MovementConfirmationControllerSpec extends ControllerLayerSpec {
+
+  private val page = new movement_confirmation_page(main_template)
+
+  private def controller(auth: AuthenticatedAction) =
+    new MovementConfirmationController(auth, stubMessagesControllerComponents(), page)
+
+  "GET" should {
+    implicit val get = FakeRequest("GET", "/")
+
+    "return 200 when authenticated" in {
+      val result = controller(SuccessfulAuth())
+        .display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR_KIND -> "kind", FlashKeys.UCR -> "123"))
+
+      status(result) mustBe Status.OK
+      contentAsHtml(result) mustBe page(JourneyType.ARRIVE, ConsignmentReferences("kind", "123"))
+    }
+
+    "return to start" when {
+      "journey type is missing" in {
+        intercept[RuntimeException] {
+          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.UCR_KIND -> "kind", FlashKeys.UCR -> "123")))
+        } mustBe ReturnToStartException
+      }
+
+      "ucr kind is missing" in {
+        intercept[RuntimeException] {
+          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR -> "123")))
+        } mustBe ReturnToStartException
+      }
+
+      "ucr is missing" in {
+        intercept[RuntimeException] {
+          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR_KIND -> "kind")))
+        } mustBe ReturnToStartException
+      }
+    }
+
+    "return 403 when unauthenticated" in {
+      val result = controller(UnsuccessfulAuth).display(get)
+
+      status(result) mustBe Status.FORBIDDEN
+    }
+  }
+}

--- a/test/controllers/movements/MovementConfirmationControllerSpec.scala
+++ b/test/controllers/movements/MovementConfirmationControllerSpec.scala
@@ -63,7 +63,9 @@ class MovementConfirmationControllerSpec extends ControllerLayerSpec {
 
       "ucr is missing" in {
         intercept[RuntimeException] {
-          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR_KIND -> "kind")))
+          await(
+            controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR_KIND -> "kind"))
+          )
         } mustBe ReturnToStartException
       }
     }

--- a/test/views/disassociate_ucr/DisassociateUcrConfirmationViewSpec.scala
+++ b/test/views/disassociate_ucr/DisassociateUcrConfirmationViewSpec.scala
@@ -16,8 +16,7 @@
 
 package views.disassociate_ucr
 
-import controllers.storage.FlashKeys
-import play.api.mvc.{AnyContentAsEmpty, Flash, Request}
+import play.api.mvc.{AnyContentAsEmpty, Request}
 import play.api.test.FakeRequest
 import views.ViewSpec
 import views.html.disassociate_ucr_confirmation
@@ -25,11 +24,10 @@ import views.html.disassociate_ucr_confirmation
 class DisassociateUcrConfirmationViewSpec extends ViewSpec {
 
   private implicit val request: Request[AnyContentAsEmpty.type] = FakeRequest().withCSRFToken
-  private val page = new disassociate_ucr_confirmation(main_template)
+  private def page = new disassociate_ucr_confirmation(main_template)
 
   "View" should {
-    implicit val flash: Flash = Flash(Map(FlashKeys.UCR -> "ucr", FlashKeys.CONSOLIDATION_KIND -> "mucr"))
-    val view = page()
+    val view = page("mucr", "ucr")
 
     "render title" in {
       view.getTitle must containMessage("disassociate.ucr.confirmation.tab.heading", "mucr", "ucr")
@@ -40,12 +38,12 @@ class DisassociateUcrConfirmationViewSpec extends ViewSpec {
     }
 
     "have 'view requests' link" in {
-      val statusInfo = page().getElementById("status-info")
+      val statusInfo = view.getElementById("status-info")
       statusInfo.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.ViewSubmissions))
     }
 
     "have 'next steps' link" in {
-      val nextSteps = page().getElementById("next-steps")
+      val nextSteps = view.getElementById("next-steps")
 
       val associate = nextSteps.getElementsByTag("a").get(0)
       associate must containMessage("disassociation.confirmation.associateOrShut.associate")

--- a/test/views/disassociate_ucr/DisassociateUcrSummaryViewSpec.scala
+++ b/test/views/disassociate_ucr/DisassociateUcrSummaryViewSpec.scala
@@ -39,7 +39,7 @@ class DisassociateUcrSummaryViewSpec extends ViewSpec {
     "render form" in {
       val form = page(answersDUCR).getForm
       form mustBe defined
-      form.get must haveAttribute("action", controllers.consolidations.routes.DisassociateUcrSummaryController.submit().url)
+      form.get must haveAttribute("action", controllers.consolidations.routes.DisassociateUCRSummaryController.submit().url)
     }
 
     "render back button" when {
@@ -47,14 +47,14 @@ class DisassociateUcrSummaryViewSpec extends ViewSpec {
         val backButton = page(answersDUCR).getBackButton
 
         backButton mustBe defined
-        backButton.get must haveHref(controllers.consolidations.routes.DisassociateUcrController.display())
+        backButton.get must haveHref(controllers.consolidations.routes.DisassociateUCRController.display())
       }
 
       "mucr" in {
         val backButton = page(answersMUCR).getBackButton
 
         backButton mustBe defined
-        backButton.get must haveHref(controllers.consolidations.routes.DisassociateUcrController.display())
+        backButton.get must haveHref(controllers.consolidations.routes.DisassociateUCRController.display())
       }
     }
 
@@ -82,13 +82,13 @@ class DisassociateUcrSummaryViewSpec extends ViewSpec {
       "ducr" in {
         val anchor: Element = page(answersDUCR).getElementById("disassociate_ucr-remove")
         anchor must containMessage("site.change")
-        anchor must haveHref(controllers.consolidations.routes.DisassociateUcrController.display())
+        anchor must haveHref(controllers.consolidations.routes.DisassociateUCRController.display())
       }
 
       "mucr" in {
         val anchor = page(answersDUCR).getElementById("disassociate_ucr-remove")
         anchor must containMessage("site.change")
-        anchor must haveHref(controllers.consolidations.routes.DisassociateUcrController.display())
+        anchor must haveHref(controllers.consolidations.routes.DisassociateUCRController.display())
       }
     }
 

--- a/test/views/disassociate_ucr/DisassociateUcrViewSpec.scala
+++ b/test/views/disassociate_ucr/DisassociateUcrViewSpec.scala
@@ -42,7 +42,7 @@ class DisassociateUcrViewSpec extends ViewSpec {
     "render form" in {
       val form = page(DisassociateUcr.form).getForm
       form mustBe defined
-      form.get must haveAttribute("action", controllers.consolidations.routes.DisassociateUcrController.submit().url)
+      form.get must haveAttribute("action", controllers.consolidations.routes.DisassociateUCRController.submit().url)
     }
 
     "render error summary" when {

--- a/test/views/movement/MovementConfirmationArrivalViewSpec.scala
+++ b/test/views/movement/MovementConfirmationArrivalViewSpec.scala
@@ -17,7 +17,7 @@
 package views.movement
 
 import forms.ConsignmentReferences
-import models.cache.ArrivalAnswers
+import models.cache.{ArrivalAnswers, JourneyType}
 import views.ViewSpec
 import views.html.movement_confirmation_page
 
@@ -25,16 +25,16 @@ class MovementConfirmationArrivalViewSpec extends ViewSpec {
 
   private implicit val request = journeyRequest(ArrivalAnswers())
 
-  val consignmentReferences = ConsignmentReferences(ConsignmentReferences.AllowedReferences.Ducr, "9GB12345678")
+  private val consignmentReferences = ConsignmentReferences(ConsignmentReferences.AllowedReferences.Ducr, "9GB12345678")
   private val page = new movement_confirmation_page(main_template)
 
   "View" should {
     "render title" in {
-      page(consignmentReferences).getTitle must containMessage("movement.ARRIVE.confirmation.tab.heading")
+      page(JourneyType.ARRIVE, consignmentReferences).getTitle must containMessage("movement.ARRIVE.confirmation.tab.heading")
     }
 
     "render confirmation" in {
-      page(consignmentReferences).getElementById("highlight-box-heading") must containMessage(
+      page(JourneyType.ARRIVE, consignmentReferences).getElementById("highlight-box-heading") must containMessage(
         "movement.ARRIVE.confirmation.heading",
         "DUCR",
         "9GB12345678"
@@ -43,19 +43,19 @@ class MovementConfirmationArrivalViewSpec extends ViewSpec {
 
     "have back to start button" in {
 
-      val backButton = page(consignmentReferences).getElementsByClass("button").first()
+      val backButton = page(JourneyType.ARRIVE, consignmentReferences).getElementsByClass("button").first()
 
       backButton must containMessage("site.backToStart")
       backButton must haveHref(controllers.routes.ChoiceController.displayPage())
     }
 
     "have 'view requests' link" in {
-      val statusInfo = page(consignmentReferences).getElementById("status-info")
+      val statusInfo = page(JourneyType.ARRIVE, consignmentReferences).getElementById("status-info")
       statusInfo.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.ViewSubmissions))
     }
 
     "have 'next steps' link" in {
-      val nextSteps = page(consignmentReferences).getElementById("next-steps")
+      val nextSteps = page(JourneyType.ARRIVE, consignmentReferences).getElementById("next-steps")
       nextSteps.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR))
       nextSteps.getElementsByTag("a").get(1) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.Departure))
     }

--- a/test/views/movement/MovementConfirmationArrivalViewSpec.scala
+++ b/test/views/movement/MovementConfirmationArrivalViewSpec.scala
@@ -34,11 +34,8 @@ class MovementConfirmationArrivalViewSpec extends ViewSpec {
     }
 
     "render confirmation" in {
-      page(JourneyType.ARRIVE, consignmentReferences).getElementById("highlight-box-heading") must containMessage(
-        "movement.ARRIVE.confirmation.heading",
-        "DUCR",
-        "9GB12345678"
-      )
+      page(JourneyType.ARRIVE, consignmentReferences)
+        .getElementById("highlight-box-heading") must containMessage("movement.ARRIVE.confirmation.heading", "DUCR", "9GB12345678")
     }
 
     "have back to start button" in {

--- a/test/views/movement/MovementConfirmationDepartureViewSpec.scala
+++ b/test/views/movement/MovementConfirmationDepartureViewSpec.scala
@@ -34,11 +34,8 @@ class MovementConfirmationDepartureViewSpec extends ViewSpec {
     }
 
     "render confirmation" in {
-      page(JourneyType.DEPART, consignmentReferences).getElementById("highlight-box-heading") must containMessage(
-        "movement.DEPART.confirmation.heading",
-        "DUCR",
-        "9GB12345678"
-      )
+      page(JourneyType.DEPART, consignmentReferences)
+        .getElementById("highlight-box-heading") must containMessage("movement.DEPART.confirmation.heading", "DUCR", "9GB12345678")
     }
 
     "have back to start button" in {

--- a/test/views/movement/MovementConfirmationDepartureViewSpec.scala
+++ b/test/views/movement/MovementConfirmationDepartureViewSpec.scala
@@ -17,7 +17,7 @@
 package views.movement
 
 import forms.ConsignmentReferences
-import models.cache.DepartureAnswers
+import models.cache.{DepartureAnswers, JourneyType}
 import views.ViewSpec
 import views.html.movement_confirmation_page
 
@@ -25,16 +25,16 @@ class MovementConfirmationDepartureViewSpec extends ViewSpec {
 
   private implicit val request = journeyRequest(DepartureAnswers())
 
-  val consignmentReferences = ConsignmentReferences(ConsignmentReferences.AllowedReferences.Ducr, "9GB12345678")
+  private val consignmentReferences = ConsignmentReferences(ConsignmentReferences.AllowedReferences.Ducr, "9GB12345678")
   private val page = new movement_confirmation_page(main_template)
 
   "View" should {
     "render title" in {
-      page(consignmentReferences).getTitle must containMessage("movement.DEPART.confirmation.tab.heading")
+      page(JourneyType.DEPART, consignmentReferences).getTitle must containMessage("movement.DEPART.confirmation.tab.heading")
     }
 
     "render confirmation" in {
-      page(consignmentReferences).getElementById("highlight-box-heading") must containMessage(
+      page(JourneyType.DEPART, consignmentReferences).getElementById("highlight-box-heading") must containMessage(
         "movement.DEPART.confirmation.heading",
         "DUCR",
         "9GB12345678"
@@ -42,20 +42,19 @@ class MovementConfirmationDepartureViewSpec extends ViewSpec {
     }
 
     "have back to start button" in {
-
-      val backButton = page(consignmentReferences).getElementsByClass("button").first()
+      val backButton = page(JourneyType.DEPART, consignmentReferences).getElementsByClass("button").first()
 
       backButton must containMessage("site.backToStart")
       backButton must haveHref(controllers.routes.ChoiceController.displayPage())
     }
 
     "have 'view requests' link" in {
-      val statusInfo = page(consignmentReferences).getElementById("status-info")
+      val statusInfo = page(JourneyType.DEPART, consignmentReferences).getElementById("status-info")
       statusInfo.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.ViewSubmissions))
     }
 
     "have 'next steps' link" in {
-      val nextSteps = page(consignmentReferences).getElementById("next-steps")
+      val nextSteps = page(JourneyType.DEPART, consignmentReferences).getElementById("next-steps")
       nextSteps.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.Departure))
       nextSteps.getElementsByTag("a").get(1) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.Arrival))
     }


### PR DESCRIPTION
It was previously POST -> show view
This means that a refresh of the confirmation screen would re-submit the movement/consolidation