### PR TITLE
CEDS-1932 Change Transport validation

### DIFF
--- a/app/controllers/movements/TransportController.scala
+++ b/app/controllers/movements/TransportController.scala
@@ -17,8 +17,8 @@
 package controllers.movements
 
 import controllers.actions.{AuthenticatedAction, JourneyRefiner}
+import controllers.exchanges.JourneyRequest
 import forms.Transport
-import forms.Transport.form
 import forms.providers.TransportFormProvider
 import javax.inject.{Inject, Singleton}
 import models.cache.{Cache, DepartureAnswers, JourneyType}
@@ -51,9 +51,6 @@ class TransportController @Inject()(
   }
 
   def saveTransport(): Action[AnyContent] = (authenticate andThen getJourney(JourneyType.DEPART)).async { implicit request =>
-    val answers = request.answersAs[DepartureAnswers]
-    val form = formProvider.provideForm(answers)
-
     form
       .bindFromRequest()
       .fold(
@@ -65,6 +62,11 @@ class TransportController @Inject()(
           }
         }
       )
+  }
+
+  private def form(implicit request: JourneyRequest[_]): Form[Transport] = {
+    val answers = request.answersAs[DepartureAnswers]
+    formProvider.provideForm(answers)
   }
 
 }

--- a/app/forms/Transport.scala
+++ b/app/forms/Transport.scala
@@ -79,8 +79,6 @@ object Transport {
     )(Transport.apply)(Transport.unapply)
     .verifying("transport.backIntoTheUk.error.allFieldsEntered", atLeastOneIsEmpty)
 
-  def form: Form[Transport] = Form(outOfTheUkMapping)
-
   def outOfTheUkForm: Form[Transport] = Form(outOfTheUkMapping)
   def backIntoTheUkForm: Form[Transport] = Form(backIntoTheUkMapping)
 }

--- a/app/forms/providers/TransportFormProvider.scala
+++ b/app/forms/providers/TransportFormProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.providers
+
+import forms.GoodsDeparted.DepartureLocation.{BackIntoTheUk, OutOfTheUk}
+import forms.{GoodsDeparted, Transport}
+import models.cache.DepartureAnswers
+import play.api.data.Form
+
+class TransportFormProvider {
+
+  def provideForm(answers: DepartureAnswers): Form[Transport] = answers.goodsDeparted match {
+    case Some(GoodsDeparted(OutOfTheUk))    => Transport.outOfTheUkForm
+    case Some(GoodsDeparted(BackIntoTheUk)) => Transport.backIntoTheUkForm
+  }
+
+}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -119,6 +119,7 @@ transport.nationality.question = What is the nationality of the transport type?
 transport.nationality.hint = This is a 2 digit country code. For example FR for France.
 transport.nationality.empty = You need to provide the transport nationality
 transport.nationality.error = Nationality of transport is incorrect
+transport.backIntoTheUk.error.allFieldsEntered = You cannot answer all three fields for an export back into the UK
 
 summary.referenceType = Consignment type
 summary.referenceValue = Consignment reference

--- a/test/controllers/movements/TransportControllerSpec.scala
+++ b/test/controllers/movements/TransportControllerSpec.scala
@@ -18,7 +18,9 @@ package controllers.movements
 
 import base.MockCache
 import controllers.ControllerLayerSpec
-import forms.Transport
+import forms.GoodsDeparted.DepartureLocation.OutOfTheUk
+import forms.providers.TransportFormProvider
+import forms.{GoodsDeparted, Transport}
 import models.cache.{Answers, ArrivalAnswers, Cache, DepartureAnswers}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -27,6 +29,7 @@ import play.api.data.Form
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
+import testdata.CommonTestData.providerId
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.transport
 
@@ -34,18 +37,21 @@ import scala.concurrent.ExecutionContext.global
 
 class TransportControllerSpec extends ControllerLayerSpec with MockCache {
 
+  private val formProvider = mock[TransportFormProvider]
   private val page = mock[transport]
 
   private def controller(answers: Answers = DepartureAnswers()) =
-    new TransportController(SuccessfulAuth(), ValidJourney(answers), cache, stubMessagesControllerComponents(), page)(global)
+    new TransportController(SuccessfulAuth(), ValidJourney(answers), cache, formProvider, stubMessagesControllerComponents(), page)(global)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
 
+    when(formProvider.provideForm(any())).thenReturn(Transport.outOfTheUkForm)
     when(page.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   override protected def afterEach(): Unit = {
+    reset(formProvider)
     reset(page)
 
     super.afterEach()
@@ -54,58 +60,82 @@ class TransportControllerSpec extends ControllerLayerSpec with MockCache {
   private def theResponseForm: Form[Transport] = {
     val captor = ArgumentCaptor.forClass(classOf[Form[Transport]])
     verify(page).apply(captor.capture())(any(), any())
-    captor.getValue()
+    captor.getValue
   }
 
-  "Location Controller" should {
+  private def answersPassedToFormProvider: DepartureAnswers = {
+    val captor = ArgumentCaptor.forClass(classOf[DepartureAnswers])
+    verify(formProvider).provideForm(captor.capture())
+    captor.getValue
+  }
+
+  "Location Controller on GET" should {
 
     "return 200 (OK)" when {
 
-      "GET displayPage is invoked without data in cache" in {
+      "invoked without data for Transport in cache" in {
 
-        givenTheCacheIsEmpty()
+        val answers = DepartureAnswers(goodsDeparted = Some(GoodsDeparted(OutOfTheUk)))
+        givenTheCacheContains(Cache(providerId, answers))
 
-        val result = controller().displayPage()(getRequest)
+        val result = controller(answers).displayPage()(getRequest)
 
         status(result) mustBe OK
         theResponseForm.value mustBe empty
       }
 
-      "GET displayPage is invoked with data in cache" in {
+      "invoked with data for Transport in cache" in {
 
-        val cachedForm = Some(Transport("1", "GB", "123"))
-        givenTheCacheContains(Cache("12345", DepartureAnswers(transport = cachedForm)))
+        val cachedGoodsDeparted = Some(GoodsDeparted(OutOfTheUk))
+        val cachedTransport = Some(Transport(Some("1"), Some("GB"), Some("123")))
+        val answers = DepartureAnswers(goodsDeparted = cachedGoodsDeparted, transport = cachedTransport)
+        givenTheCacheContains(Cache(providerId, answers))
 
-        val result = controller(DepartureAnswers(transport = cachedForm)).displayPage()(getRequest)
+        val result = controller(answers).displayPage()(getRequest)
 
         status(result) mustBe OK
-
-        theResponseForm.value mustBe cachedForm
+        theResponseForm.value mustBe cachedTransport
       }
     }
 
-    "return 400 (BAD_REQUEST)" when {
+    "return 303 (SEE_OTHER)" when {
 
-      "POST submit is invoked with incorrect form" in {
+      "there is no goods departed in the cache" in {
 
         givenTheCacheIsEmpty()
 
-        val invalidForm = Json.toJson(Transport("99", "Invalid", "Invalid"))
+        val result = controller(DepartureAnswers()).displayPage()(getRequest)
 
-        val result = controller().saveTransport()(postRequest(invalidForm))
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).get mustBe routes.GoodsDepartedController.displayPage().url
+      }
+    }
+  }
+
+  "Location Controller on POST" when {
+
+    "provided with incorrect form" should {
+
+      "return 400 (BAD_REQUEST)" in {
+
+        val answers = DepartureAnswers(goodsDeparted = Some(GoodsDeparted(OutOfTheUk)))
+        givenTheCacheContains(Cache(providerId, answers))
+
+        val invalidForm = Json.toJson(Transport(Some("99"), Some("Invalid"), Some("Invalid")))
+
+        val result = controller(answers).saveTransport()(postRequest(invalidForm))
 
         status(result) mustBe BAD_REQUEST
       }
-
     }
 
-    "return 403 (FORBIDDEN)" when {
+    "user is on a different journey" should {
 
-      "POST submit is invoked with incorrect answers" in {
+      "return 403 (FORBIDDEN)" in {
 
         givenTheCacheIsEmpty()
 
-        val correctForm = Json.toJson(Transport("1", "GB", "123"))
+        val correctForm = Json.toJson(Transport(Some("1"), Some("GB"), Some("123")))
 
         val result = controller(ArrivalAnswers()).saveTransport()(postRequest(correctForm))
 
@@ -113,19 +143,33 @@ class TransportControllerSpec extends ControllerLayerSpec with MockCache {
       }
     }
 
-    "return 303 (SEE_OTHER)" when {
+    "provided with correct form for departure" should {
 
-      "POST submit is invoked with correct form for departure" in {
+      "call FormProvider passing answers with GoodsDeparted element" in {
 
-        givenTheCacheIsEmpty()
+        val answers = DepartureAnswers(goodsDeparted = Some(GoodsDeparted(OutOfTheUk)))
+        givenTheCacheContains(Cache(providerId, answers))
 
-        val correctForm = Json.toJson(Transport("1", "GB", "123"))
+        val correctForm = Json.toJson(Transport(Some("1"), Some("GB"), Some("123")))
 
-        val result = controller(DepartureAnswers()).saveTransport()(postRequest(correctForm))
+        await(controller(answers).saveTransport()(postRequest(correctForm)))
+
+        answersPassedToFormProvider mustBe answers
+      }
+
+      "return 303 (SEE_OTHER)" in {
+
+        val answers = DepartureAnswers(goodsDeparted = Some(GoodsDeparted(OutOfTheUk)))
+        givenTheCacheContains(Cache(providerId, answers))
+
+        val correctForm = Json.toJson(Transport(Some("1"), Some("GB"), Some("123")))
+
+        val result = controller(answers).saveTransport()(postRequest(correctForm))
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(controllers.movements.routes.MovementSummaryController.displayPage().url)
       }
     }
   }
+
 }

--- a/test/forms/TransportSpec.scala
+++ b/test/forms/TransportSpec.scala
@@ -19,6 +19,7 @@ package forms
 import base.UnitSpec
 import forms.Transport.ModesOfTransport._
 import play.api.data.FormError
+import play.api.libs.json.Json
 import testdata.TestDataHelper.createRandomAlphanumericString
 
 class TransportSpec extends UnitSpec {
@@ -44,55 +45,325 @@ class TransportSpec extends UnitSpec {
 
     "contains all allowed modes of transport" in {
 
-      Transport.allowedModeOfTransport.length must be(8)
-      Transport.allowedModeOfTransport must contain(Sea)
-      Transport.allowedModeOfTransport must contain(Rail)
-      Transport.allowedModeOfTransport must contain(Road)
-      Transport.allowedModeOfTransport must contain(Air)
-      Transport.allowedModeOfTransport must contain(PostalOrMail)
-      Transport.allowedModeOfTransport must contain(FixedInstallations)
-      Transport.allowedModeOfTransport must contain(InlandWaterway)
-      Transport.allowedModeOfTransport must contain(Other)
+      Transport.allowedModesOfTransport.size must be(8)
+      Transport.allowedModesOfTransport must contain(Sea)
+      Transport.allowedModesOfTransport must contain(Rail)
+      Transport.allowedModesOfTransport must contain(Road)
+      Transport.allowedModesOfTransport must contain(Air)
+      Transport.allowedModesOfTransport must contain(PostalOrMail)
+      Transport.allowedModesOfTransport must contain(FixedInstallations)
+      Transport.allowedModesOfTransport must contain(InlandWaterway)
+      Transport.allowedModesOfTransport must contain(Other)
     }
-
   }
 
-  "Transport mapping" should {
+  "Transport Out of the UK mapping" should {
 
-    "return error" when {
+    "contain errors" when {
 
-      "mode of transport, reference and nationality are empty" in {
+      "all 3 values are empty" in {
 
-        val inputData = Transport("", "", "")
-        val errors = Transport.form.fillAndValidate(inputData).errors
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "", "transportId" -> "")
 
-        errors.length must be(3)
-        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 3
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.empty"))
         errors(1) must be(FormError("nationality", "transport.nationality.empty"))
         errors(2) must be(FormError("transportId", "transport.transportId.empty"))
       }
 
-      "mode of transport, reference and nationality are incorrect" in {
+      "only modeOfTransport is entered" in {
 
-        val inputData = Transport("incorrect", "incorrect", createRandomAlphanumericString(36))
-        val errors = Transport.form.fillAndValidate(inputData).errors
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "", "transportId" -> "")
 
-        errors.length must be(3)
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("nationality", "transport.nationality.empty"))
+        errors(1) must be(FormError("transportId", "transport.transportId.empty"))
+      }
+
+      "only nationality is entered" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "GB", "transportId" -> "")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.empty"))
+        errors(1) must be(FormError("transportId", "transport.transportId.empty"))
+      }
+
+      "only transportId is entered" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "", "transportId" -> "Reference")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.empty"))
+        errors(1) must be(FormError("nationality", "transport.nationality.empty"))
+      }
+
+      "modeOfTransport is empty" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "GB", "transportId" -> "Reference")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("modeOfTransport", "transport.modeOfTransport.empty"))
+      }
+
+      "nationality is empty" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "", "transportId" -> "Reference")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("nationality", "transport.nationality.empty"))
+      }
+
+      "transportId is empty" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "GB", "transportId" -> "")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("transportId", "transport.transportId.empty"))
+      }
+
+      "provided with 3 incorrect values" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "invalid", "transportId" -> createRandomAlphanumericString(36))
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 3
         errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
         errors(1) must be(FormError("nationality", "transport.nationality.error"))
         errors(2) must be(FormError("transportId", "transport.transportId.error"))
       }
+
+      "provided with only modeOfTransport being correct" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "invalid", "transportId" -> "Reference!@#$%^")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("nationality", "transport.nationality.error"))
+        errors(1) must be(FormError("transportId", "transport.transportId.error"))
+      }
+
+      "provided with only nationality being correct" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "GB", "transportId" -> "Reference!@#$%^")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+        errors(1) must be(FormError("transportId", "transport.transportId.error"))
+      }
+
+      "provided with only transportId being correct" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "invalid", "transportId" -> "Reference")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+        errors(1) must be(FormError("nationality", "transport.nationality.error"))
+      }
+
+      "provided with incorrect modeOfTransport" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "GB", "transportId" -> "Reference")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+      }
+
+      "provided with incorrect nationality" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "invalid", "transportId" -> "Reference")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("nationality", "transport.nationality.error"))
+      }
+
+      "provided with incorrect transportId" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "GB", "transportId" -> "Reference!@#$%^")
+
+        val errors = Transport.outOfTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("transportId", "transport.transportId.error"))
+      }
     }
 
-    "return no error" when {
+    "contain no errors" when {
 
-      "values are correct for different country codes" in {
-        val transportPoland = Transport(Sea, "PL", "Reference")
-        Transport.form.fillAndValidate(transportPoland).errors mustBe empty
+      "all 3 values are correct" in {
 
-        val transportFinland = Transport(Rail, "FI", "SHIP-123")
-        Transport.form.fillAndValidate(transportFinland).errors mustBe empty
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "GB", "transportId" -> "Reference")
+
+        Transport.outOfTheUkForm.bind(inputData).errors mustBe empty
       }
     }
   }
+
+  "Transport Back into the UK mapping" should {
+
+    "contain errors" when {
+
+      "provided with 3 correct values" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "GB", "transportId" -> "Reference")
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("", "transport.backIntoTheUk.error.allFieldsEntered"))
+      }
+
+      "provided with 3 incorrect values" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "invalid", "transportId" -> createRandomAlphanumericString(36))
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 3
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+        errors(1) must be(FormError("nationality", "transport.nationality.error"))
+        errors(2) must be(FormError("transportId", "transport.transportId.error"))
+      }
+
+      "provided with only modeOfTransport being correct" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "invalid", "transportId" -> "Reference!@#$%^")
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("nationality", "transport.nationality.error"))
+        errors(1) must be(FormError("transportId", "transport.transportId.error"))
+      }
+
+      "provided with only nationality being correct" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "GB", "transportId" -> "Reference!@#$%^")
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+        errors(1) must be(FormError("transportId", "transport.transportId.error"))
+      }
+
+      "provided with only transportId being correct" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "invalid", "transportId" -> "Reference")
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 2
+        errors(0) must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+        errors(1) must be(FormError("nationality", "transport.nationality.error"))
+      }
+
+      "provided with incorrect modeOfTransport" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "13", "nationality" -> "GB", "transportId" -> "Reference")
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("modeOfTransport", "transport.modeOfTransport.error"))
+      }
+
+      "provided with incorrect nationality" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "invalid", "transportId" -> "Reference")
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("nationality", "transport.nationality.error"))
+      }
+
+      "provided with incorrect transportId" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "GB", "transportId" -> "Reference!@#$%^")
+
+        val errors = Transport.backIntoTheUkForm.bind(inputData).errors
+
+        errors.length mustBe 1
+        errors.head must be(FormError("transportId", "transport.transportId.error"))
+      }
+    }
+
+    "contain no errors" when {
+
+      "all 3 values are empty" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "", "transportId" -> "")
+
+        Transport.backIntoTheUkForm.bind(inputData).errors mustBe empty
+      }
+
+      "only modeOfTransport is entered" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "", "transportId" -> "")
+
+        Transport.backIntoTheUkForm.bind(inputData).errors mustBe empty
+      }
+
+      "only nationality is entered" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "GB", "transportId" -> "")
+
+        Transport.backIntoTheUkForm.bind(inputData).errors mustBe empty
+      }
+
+      "only transportId is entered" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "", "transportId" -> "Reference")
+
+        Transport.backIntoTheUkForm.bind(inputData).errors mustBe empty
+      }
+
+      "modeOfTransport is empty" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "", "nationality" -> "GB", "transportId" -> "Reference")
+
+        Transport.backIntoTheUkForm.bind(inputData).errors mustBe empty
+      }
+
+      "nationality is empty" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "", "transportId" -> "Reference")
+
+        Transport.backIntoTheUkForm.bind(inputData).errors mustBe empty
+      }
+
+      "transportId is empty" in {
+
+        val inputData = Json.obj("modeOfTransport" -> "1", "nationality" -> "GB", "transportId" -> "")
+
+        Transport.backIntoTheUkForm.bind(inputData).errors mustBe empty
+      }
+    }
+  }
+
 }

--- a/test/forms/providers/TransportFormProviderSpec.scala
+++ b/test/forms/providers/TransportFormProviderSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.providers
+
+import base.UnitSpec
+import forms.GoodsDeparted.DepartureLocation.{BackIntoTheUk, OutOfTheUk}
+import forms.{GoodsDeparted, Transport}
+import models.cache.DepartureAnswers
+
+class TransportFormProviderSpec extends UnitSpec {
+
+  private val formProvider = new TransportFormProvider()
+
+  "TransportFormProvider" should {
+
+    "return Out of the UK form" when {
+
+      "provided with answers containing OutOfTheUk value for GoodsDeparted" in {
+
+        val answers = DepartureAnswers(goodsDeparted = Some(GoodsDeparted(OutOfTheUk)))
+
+        val form = formProvider.provideForm(answers)
+
+        form mustBe Transport.outOfTheUkForm
+      }
+    }
+
+    "return Back into the UK form" when {
+
+      "provided with answers containing BackIntoTheUk value for GoodsDeparted" in {
+
+        val answers = DepartureAnswers(goodsDeparted = Some(GoodsDeparted(BackIntoTheUk)))
+
+        val form = formProvider.provideForm(answers)
+
+        form mustBe Transport.backIntoTheUkForm
+      }
+    }
+  }
+
+}

--- a/test/views/movement/TransportViewSpec.scala
+++ b/test/views/movement/TransportViewSpec.scala
@@ -29,23 +29,23 @@ class TransportViewSpec extends ViewSpec {
 
   "View" should {
     "render title" in {
-      page(Transport.form).getTitle must containMessage("transport.title")
+      page(Transport.outOfTheUkForm).getTitle must containMessage("transport.title")
     }
 
     "render input for mode of transport" in {
-      page(Transport.form).getElementById("modeOfTransport-label") must containMessage("transport.modeOfTransport.question")
+      page(Transport.outOfTheUkForm).getElementById("modeOfTransport-label") must containMessage("transport.modeOfTransport.question")
       for (i <- 1 to 8) {
-        page(Transport.form).getElementById(s"$i-label") must containMessage(s"transport.modeOfTransport.$i")
+        page(Transport.outOfTheUkForm).getElementById(s"$i-label") must containMessage(s"transport.modeOfTransport.$i")
       }
     }
 
     "render input for nationality" in {
-      page(Transport.form).getElementById("nationality-label") must containMessage("transport.nationality.question")
-      page(Transport.form).getElementById("nationality-hint") must containMessage("transport.nationality.hint")
+      page(Transport.outOfTheUkForm).getElementById("nationality-label") must containMessage("transport.nationality.question")
+      page(Transport.outOfTheUkForm).getElementById("nationality-hint") must containMessage("transport.nationality.hint")
     }
 
     "render back button" in {
-      val backButton = page(Transport.form).getBackButton
+      val backButton = page(Transport.outOfTheUkForm).getBackButton
 
       backButton mustBe defined
       backButton.get must haveHref(controllers.movements.routes.GoodsDepartedController.displayPage())
@@ -53,11 +53,11 @@ class TransportViewSpec extends ViewSpec {
 
     "render error summary" when {
       "no errors" in {
-        page(Transport.form).getErrorSummary mustBe empty
+        page(Transport.outOfTheUkForm).getErrorSummary mustBe empty
       }
 
       "some errors" in {
-        page(Transport.form.withError("error", "error.required")).getErrorSummary mustBe defined
+        page(Transport.outOfTheUkForm.withError("error", "error.required")).getErrorSummary mustBe defined
       }
     }
   }


### PR DESCRIPTION
To give you some context:
Validation on Transport page is different depending on the users choice on GoodsDeparted page. In this PR you can see both validations/mappings added and the logic for providing correct form with the mapping.

There are 2 mappings added for different export scenarios:
1. Out of the UK
2. Back into the UK

Also, there is TransportFormProvider added. To separate logic for
providing correct form and to simplify tests.