### PR TITLE
CEDS-2046 Re-Enable Audit ITs

### DIFF
--- a/app/services/audit/AuditService.scala
+++ b/app/services/audit/AuditService.scala
@@ -44,7 +44,7 @@ class AuditService @Inject()(connector: AuditConnector, @Named("appName") appNam
   def auditDisassociate(providerId: String, ucr: String, result: String)(implicit hc: HeaderCarrier): Future[AuditResult] =
     audit(
       AuditType.AuditDisassociate,
-      Map(EventData.providerId.toString -> providerId, EventData.ducr.toString -> ucr, EventData.submissionResult.toString -> result)
+      Map(EventData.providerId.toString -> providerId, EventData.ucr.toString -> ucr, EventData.submissionResult.toString -> result)
     )
 
   def auditAssociate(providerId: String, mucr: String, ducr: String, result: String)(implicit hc: HeaderCarrier): Future[AuditResult] =

--- a/test/it/ArrivalSpec.scala
+++ b/test/it/ArrivalSpec.scala
@@ -17,7 +17,7 @@
 import java.time.temporal.ChronoUnit
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, matchingJsonPath, verify}
 import forms.common.{Date, Time}
 import forms.{ArrivalDetails, ArrivalReference, ConsignmentReferences, Location}
 import models.cache.ArrivalAnswers
@@ -268,6 +268,16 @@ class ArrivalSpec extends IntegrationSpec {
                    |"location":{"code":"GBAUEMAEMAEMA"},
                    |"arrivalReference":{"reference":"ABC"}
                    |}""".stripMargin))
+        )
+        verifyEventually(
+          postRequestedForAudit()
+            .withRequestBody(matchingJsonPath("auditType", equalTo("Arrival")))
+            .withRequestBody(matchingJsonPath("detail.providerId", equalTo("pid")))
+            .withRequestBody(matchingJsonPath("detail.ucr", equalTo("GB/123-12345")))
+            .withRequestBody(matchingJsonPath("detail.ucrType", equalTo("M")))
+            .withRequestBody(matchingJsonPath("detail.messageCode", equalTo("EAL")))
+            .withRequestBody(matchingJsonPath("detail.movementReference", equalTo("ABC")))
+            .withRequestBody(matchingJsonPath("detail.submissionResult", equalTo("Success")))
         )
       }
     }

--- a/test/it/AssociateUcrSpec.scala
+++ b/test/it/AssociateUcrSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, verify}
 import forms.MucrOptions.CreateOrAddValues.Create
 import forms.{AssociateKind, AssociateUcr, MucrOptions}
 import models.cache.AssociateUcrAnswers
@@ -121,6 +121,14 @@ class AssociateUcrSpec extends IntegrationSpec {
                 """{"providerId":"pid","eori":"GB1234567890","mucr":"GB/123-12345","ucr":"GB/321-54321","consolidationType":"ASSOCIATE_DUCR"}"""
               )
             )
+        )
+        verifyEventually(
+          postRequestedForAudit()
+            .withRequestBody(matchingJsonPath("auditType", equalTo("Associate")))
+            .withRequestBody(matchingJsonPath("detail.providerId", equalTo("pid")))
+            .withRequestBody(matchingJsonPath("detail.mucr", equalTo("GB/123-12345")))
+            .withRequestBody(matchingJsonPath("detail.ducr", equalTo("GB/321-54321")))
+            .withRequestBody(matchingJsonPath("detail.submissionResult", equalTo("Success")))
         )
       }
     }

--- a/test/it/DepartureSpec.scala
+++ b/test/it/DepartureSpec.scala
@@ -17,7 +17,7 @@
 import java.time.temporal.ChronoUnit
 import java.time.{LocalDate, LocalDateTime, LocalTime, ZoneOffset}
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, matchingJsonPath, verify}
 import forms.GoodsDeparted.DepartureLocation
 import forms._
 import forms.common.{Date, Time}
@@ -332,6 +332,15 @@ class DepartureSpec extends IntegrationSpec {
                    |"location":{"code":"GBAUEMAEMAEMA"},
                    |"transport":{"modeOfTransport":"1","nationality":"FR","transportId":"123"}
                    |}""".stripMargin))
+        )
+        verifyEventually(
+          postRequestedForAudit()
+            .withRequestBody(matchingJsonPath("auditType", equalTo("Departure")))
+            .withRequestBody(matchingJsonPath("detail.providerId", equalTo("pid")))
+            .withRequestBody(matchingJsonPath("detail.ucr", equalTo("GB/123-12345")))
+            .withRequestBody(matchingJsonPath("detail.ucrType", equalTo("M")))
+            .withRequestBody(matchingJsonPath("detail.messageCode", equalTo("EDL")))
+            .withRequestBody(matchingJsonPath("detail.submissionResult", equalTo("Success")))
         )
       }
     }

--- a/test/it/DissociateUcrSpec.scala
+++ b/test/it/DissociateUcrSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, verify}
 import forms.{DisassociateKind, DisassociateUcr}
 import models.cache.DisassociateUcrAnswers
 import play.api.test.Helpers._
@@ -93,6 +93,13 @@ class DissociateUcrSpec extends IntegrationSpec {
         verify(
           postRequestedForConsolidation()
             .withRequestBody(equalTo("""{"providerId":"pid","eori":"GB1234567890","ucr":"GB/321-54321","consolidationType":"DISASSOCIATE_DUCR"}"""))
+        )
+        verifyEventually(
+          postRequestedForAudit()
+            .withRequestBody(matchingJsonPath("auditType", equalTo("Disassociate")))
+            .withRequestBody(matchingJsonPath("detail.providerId", equalTo("pid")))
+            .withRequestBody(matchingJsonPath("detail.ucr", equalTo("GB/321-54321")))
+            .withRequestBody(matchingJsonPath("detail.submissionResult", equalTo("Success")))
         )
       }
     }

--- a/test/it/IntegrationSpec.scala
+++ b/test/it/IntegrationSpec.scala
@@ -74,9 +74,6 @@ abstract class IntegrationSpec
 
   protected def givenCacheFor(pid: String, answers: Answers): Unit = await(cacheRepository.insert(Cache.format.writes(Cache(pid, answers))))
 
-  protected def verifyEventually(requestPatternBuilder: RequestPatternBuilder): Unit =
-    eventually {
-      WireMock.verify(requestPatternBuilder)
-    }
+  protected def verifyEventually(requestPatternBuilder: RequestPatternBuilder): Unit = eventually(WireMock.verify(requestPatternBuilder))
 
 }

--- a/test/it/ShutMucrSpec.scala
+++ b/test/it/ShutMucrSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, verify}
 import forms.ShutMucr
 import models.cache.ShutMucrAnswers
 import play.api.test.Helpers._
@@ -85,6 +85,13 @@ class ShutMucrSpec extends IntegrationSpec {
         verify(
           postRequestedForConsolidation()
             .withRequestBody(equalTo("""{"providerId":"pid","eori":"GB1234567890","mucr":"GB/123-12345","consolidationType":"SHUT_MUCR"}"""))
+        )
+        verifyEventually(
+          postRequestedForAudit()
+            .withRequestBody(matchingJsonPath("auditType", equalTo("ShutMucr")))
+            .withRequestBody(matchingJsonPath("detail.providerId", equalTo("pid")))
+            .withRequestBody(matchingJsonPath("detail.mucr", equalTo("GB/123-12345")))
+            .withRequestBody(matchingJsonPath("detail.submissionResult", equalTo("Success")))
         )
       }
     }

--- a/test/unit/services/audit/AuditServiceSpec.scala
+++ b/test/unit/services/audit/AuditServiceSpec.scala
@@ -203,7 +203,7 @@ class AuditServiceSpec extends UnitSpec with BeforeAndAfterEach {
         val auditTags = auditTagsResult("Disassociate")
         val auditDetail = Map(
           EventData.providerId.toString -> CommonTestData.providerId,
-          EventData.ducr.toString -> "ducr",
+          EventData.ucr.toString -> "ducr",
           EventData.submissionResult.toString -> "200"
         )
         val expectedDataEvent =


### PR DESCRIPTION
They were removed previously as they were flakey

This is because the submission service doesn't chain the future returned by the AuditService so it completes in parallel, not necessarily before the verify is called.

The behaviour above is desired, we don't want to couple the success of a submission to whether the Audit Service is up & performant, so I've changed the tests to `verifyEventually` instead of immediately