### PR TITLE
Fix Date and Time forms

### DIFF
--- a/app/forms/common/Date.scala
+++ b/app/forms/common/Date.scala
@@ -16,10 +16,11 @@
 
 package forms.common
 
+import java.text.DecimalFormat
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-import play.api.data.Forms.{number, optional}
+import play.api.data.Forms.text
 import play.api.data.{Forms, Mapping}
 import play.api.libs.json.{Json, OFormat}
 
@@ -34,7 +35,7 @@ case class Date(date: LocalDate) {
   def to102Format: String = date.format(format102)
 
   def to304Format: String = {
-    import java.time.{LocalDate, LocalTime}
+    import java.time.LocalTime
     date.atTime(LocalTime.of(0, 0, 0)).format(DateTimeFormatter.ISO_DATE_TIME)
 
   }
@@ -51,39 +52,40 @@ object Date {
   val monthKey = "month"
   val dayKey = "day"
 
-  private val correctDay: Int => Boolean = (day: Int) => day >= 1 && day <= 31
-  private val correctMonth: Int => Boolean = (month: Int) => month >= 1 && month <= 12
-  private val correctYear: Int => Boolean = (year: Int) => year >= 2000 && year <= 2099
-
   val mapping: Mapping[Date] = {
 
-    def validate(day: Option[Int], month: Option[Int], year: Option[Int]): Boolean =
-      (day, month, year) match {
-        case (Some(d), Some(m), Some(y)) => Try(LocalDate.of(y, m, d)).isSuccess
-        case _                           => false
-      }
+    def build(day: Try[Int], month: Try[Int], year: Try[Int]): Try[LocalDate] =
+      for {
+        d <- day
+        m <- month
+        y <- year
+      } yield LocalDate.of(y, m, d)
 
-    def bind(day: Option[Int], month: Option[Int], year: Option[Int]): Date =
-      (day, month, year) match {
-        case (Some(d), Some(m), Some(y)) => Date(LocalDate.of(y, m, d))
-        case _                           => throw new IllegalArgumentException("Could not bind local date when any is empty")
-      }
+    def validate(day: Try[Int], month: Try[Int], year: Try[Int]): Boolean = build(day, month, year).isSuccess
 
-    def unbind(date: Date): (Option[Int], Option[Int], Option[Int]) = {
+    def bind(day: Try[Int], month: Try[Int], year: Try[Int]): Date =
+      build(day, month, year)
+        .map(apply)
+        .getOrElse(throw new IllegalArgumentException("Could not bind local date when any is empty"))
+
+    def unbind(date: Date): (Try[Int], Try[Int], Try[Int]) = {
       val value = date.date
-      (Some(value.getDayOfMonth), Some(value.getMonthValue), Some(value.getYear))
+      (Try(value.getDayOfMonth), Try(value.getMonthValue), Try(value.getYear))
+    }
+
+    val twoDigitMapping: Mapping[Try[Int]] = {
+      val formatter = new DecimalFormat("00")
+      text().transform[Try[Int]](value => Try(value.toInt), _.map(value => formatter.format(value)).getOrElse(""))
+    }
+
+    val fourDigitMapping: Mapping[Try[Int]] = {
+      val formatter = new DecimalFormat("0000")
+      text().transform[Try[Int]](value => Try(value.toInt), _.map(value => formatter.format(value)).getOrElse(""))
     }
 
     Forms
-      .tuple(
-        dayKey -> optional(number().verifying("dateTime.date.day.error", correctDay))
-          .verifying("dateTime.date.day.empty", _.nonEmpty),
-        monthKey -> optional(number().verifying("dateTime.date.month.error", correctMonth))
-          .verifying("dateTime.date.month.empty", _.nonEmpty),
-        yearKey -> optional(number().verifying("dateTime.date.year.error", correctYear))
-          .verifying("dateTime.date.year.empty", _.nonEmpty)
-      )
-      .verifying("dateTime.date.error.format", (validate _).tupled)
+      .tuple(dayKey -> twoDigitMapping, monthKey -> twoDigitMapping, yearKey -> fourDigitMapping)
+      .verifying("date.error.invalid", (validate _).tupled)
       .transform((bind _).tupled, unbind)
   }
 }

--- a/app/forms/common/Time.scala
+++ b/app/forms/common/Time.scala
@@ -16,9 +16,10 @@
 
 package forms.common
 
+import java.text.DecimalFormat
 import java.time.LocalTime
 
-import play.api.data.Forms.{optional, text}
+import play.api.data.Forms.text
 import play.api.data.{Forms, Mapping}
 import play.api.libs.json.{Json, OFormat}
 
@@ -27,7 +28,6 @@ import scala.util.Try
 case class Time(time: LocalTime) {
 
   override def toString: String = time.toString
-
 }
 
 object Time {
@@ -36,26 +36,29 @@ object Time {
   val hourKey = "hour"
   val minuteKey = "minute"
 
-  private val correctHour: String => Boolean = (hour: String) => Try(hour.toInt).map(value => value >= 0 && value <= 23).getOrElse(false)
-
-  private val correctMinute: String => Boolean = (minute: String) => Try(minute.toInt).map(value => value >= 0 && value <= 59).getOrElse(false)
-
   val mapping: Mapping[Time] = {
-    def bind(hour: Option[String], minutes: Option[String]): Time =
-      (hour, minutes) match {
-        case (Some(h), Some(m)) => Time(LocalTime.of(h.toInt, m.toInt))
-        case _                  => throw new IllegalArgumentException("Could not build time - missing one of parameters")
-      }
+    def build(hour: Try[Int], minutes: Try[Int]): Try[LocalTime] =
+      for {
+        h <- hour
+        m <- minutes
+      } yield LocalTime.of(h, m)
 
-    def unbind(time: Time): Option[(Option[String], Option[String])] =
-      Some((Some(time.time.getHour.toString), Some(time.time.getMinute.toString)))
+    def bind(hour: Try[Int], minutes: Try[Int]): Time =
+      build(hour, minutes)
+        .map(apply)
+        .getOrElse(throw new IllegalArgumentException("Could not build time - missing one of parameters"))
+
+    def unbind(time: Time): (Try[Int], Try[Int]) =
+      (Try(time.time.getHour), Try(time.time.getMinute))
+
+    val twoDigitFormatter: Mapping[Try[Int]] = {
+      val formatter = new DecimalFormat("00")
+      text().transform(value => Try(value.toInt), _.map(value => formatter.format(value)).getOrElse(""))
+    }
 
     Forms
-      .mapping(
-        hourKey -> optional(text().verifying("dateTime.time.hour.error", correctHour))
-          .verifying("dateTime.time.hour.empty", _.nonEmpty),
-        minuteKey -> optional(text().verifying("dateTime.time.minute.error", correctMinute))
-          .verifying("dateTime.time.minute.empty", _.nonEmpty)
-      )(bind)(unbind)
+      .tuple(hourKey -> twoDigitFormatter, minuteKey -> twoDigitFormatter)
+      .verifying("time.error.invalid", (build _).tupled.andThen(_.isSuccess))
+      .transform((bind _).tupled, unbind)
   }
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -26,6 +26,9 @@ error.summary.text = Check the following
 error.mucr.empty = MUCR number cannot be empty
 error.mucr.format = MUCR number is in incorrect format
 
+date.error.invalid = Date is incorrect
+time.error.invalid = Time is incorrect
+
 movement.choice.title = What do you want to do?
 movement.choice.arrival.label = Arrive a consignment
 movement.choice.departure.label = Depart a consignment
@@ -80,18 +83,6 @@ departureDetails.time.hint = For example, 21 37
 
 departure.details.error.overdue = Time of Departure cannot be more than 60 days in the past
 departure.details.error.future = Time of Departure cannot be in the future
-
-dateTime.date.error.format = Date format is incorrect
-dateTime.date.day.empty = Day cannot be empty
-dateTime.date.day.error = Day is incorrect
-dateTime.date.month.empty = Month cannot be empty
-dateTime.date.month.error = Month is incorrect
-dateTime.date.year.empty = Year cannot be empty
-dateTime.date.year.error = Year is incorrect
-dateTime.time.hour.empty = Hour cannot be empty
-dateTime.time.hour.error = Hour is incorrect
-dateTime.time.minute.empty = Minute cannot be empty
-dateTime.time.minute.error = Minute is incorrect
 
 location.title = Location
 location.sectionHeader.retrospectiveArrival = Retrospectively arrive a consignment

--- a/test/unit/forms/DepartureDetailsSpec.scala
+++ b/test/unit/forms/DepartureDetailsSpec.scala
@@ -20,6 +20,7 @@ import java.time.{LocalDate, LocalTime}
 
 import base.UnitSpec
 import forms.common.{Date, Time}
+import matchers.FormMatchers
 import testdata.MovementsTestData
 
 class DepartureDetailsSpec extends UnitSpec with FormMatchers {

--- a/test/unit/forms/common/DateSpec.scala
+++ b/test/unit/forms/common/DateSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.common
+
+import java.time.LocalDate
+
+import base.UnitSpec
+import play.api.data.{Form, FormError}
+
+class DateSpec extends UnitSpec {
+
+  val form: Form[Date] = Form(Date.mapping)
+
+  "Date" should {
+
+    "correct convert date to 102 format" in {
+
+      val dateInput = Date(LocalDate.of(2019, 1, 1))
+
+      dateInput.to102Format must be("20190101")
+    }
+
+    "return string in uuuu-MM-dd format for toString method" in {
+
+      val dateInput = Date(LocalDate.of(2020, 3, 3))
+
+      dateInput.toString must be("2020-03-03")
+    }
+  }
+
+  "Object Date" should {
+
+    "contains all necessary, correct keys" in {
+
+      Date.dayKey must be("day")
+      Date.monthKey must be("month")
+      Date.yearKey must be("year")
+    }
+  }
+
+  "Date mapping" should {
+
+    "return error" when {
+
+      "date has incorrect format" in {
+
+        val dateInput = Map("day" -> "31", "month" -> "2", "year" -> "2020")
+        val errors = form.bind(dateInput).errors
+
+        errors.length must be(1)
+        errors.head must be(FormError("", "date.error.invalid"))
+      }
+    }
+
+    "return no error for correct date" in {
+
+      val dateInput = Map("day" -> "15", "month" -> "1", "year" -> "2020")
+      val errors = form.bind(dateInput).errors
+
+      errors.length must be(0)
+    }
+  }
+}

--- a/test/unit/forms/common/TimeSpec.scala
+++ b/test/unit/forms/common/TimeSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.common
+
+import java.time.LocalTime
+
+import base.UnitSpec
+import matchers.FormMatchers
+import play.api.data.{Form, FormError}
+
+class TimeSpec extends UnitSpec with FormMatchers {
+
+  val form: Form[Time] = Form(Time.mapping)
+
+  "Time" should {
+
+    "return string in HH:mm format" in {
+
+      val time = Time(LocalTime.of(10, 10))
+
+      time.toString must be("10:10")
+    }
+
+    "format time when user use values like 1, 2, 3, etc..." in {
+
+      val time = Time(LocalTime.of(1, 1))
+      val formattedTime = time.toString
+
+      formattedTime mustEqual "01:01"
+    }
+  }
+
+  "Time object" should {
+
+    "contain all necessary, correct keys" in {
+
+      Time.hourKey must be("hour")
+      Time.minuteKey must be("minute")
+    }
+  }
+
+  "Time mapping" should {
+
+    "return error" when {
+
+      "hour and minute is empty" in {
+
+        val errors = form.bind(Map.empty[String, String]).errors
+
+        errors must contain theSameElementsAs List(FormError("hour", "error.required"), FormError("minute", "error.required"))
+      }
+
+      "hour and minute is incorrect" in {
+        val errors = form.bind(Map("hour" -> "24", "minute" -> "60")).errors
+
+        errors must contain theSameElementsAs List(FormError("", "time.error.invalid"))
+      }
+    }
+
+    "return no error" when {
+
+      "time has correct values" in {
+
+        val inputTime = Map("hour" -> "10", "minute" -> "10")
+        val forms = form.bind(inputTime)
+
+        forms mustBe withoutErrors
+      }
+    }
+  }
+}

--- a/test/util/matchers/FormMatchers.scala
+++ b/test/util/matchers/FormMatchers.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package forms
+package matchers
 
 import org.scalatest.matchers.{BeMatcher, MatchResult}
 import play.api.data.{Form, FormError}


### PR DESCRIPTION
There was a problem making some of our regression tests failing. It was
non-deterministic and hard to reason about.
The cause turned out to be the DateTime formatting and displaying those
on the pages. The pattern is to have 2 digit hour and minute but the
previous implementation did not cover that.

The solution is a copy from External Movements service, where the same
problem has been resolved.