### PR TITLE
Dependencies update

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/config/ErrorHandler.scala
+++ b/app/config/ErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/CustomsDeclareExportsMovementsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsMovementsConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/StrideAuthConnector.scala
+++ b/app/connectors/StrideAuthConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/exchanges/ConsolidationExchange.scala
+++ b/app/connectors/exchanges/ConsolidationExchange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/exchanges/MovementDetailsExchange.scala
+++ b/app/connectors/exchanges/MovementDetailsExchange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/exchanges/MovementExchange.scala
+++ b/app/connectors/exchanges/MovementExchange.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/exchanges/MovementType.scala
+++ b/app/connectors/exchanges/MovementType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/connectors/formats/Implicit.scala
+++ b/app/connectors/formats/Implicit.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ViewNotificationsController.scala
+++ b/app/controllers/ViewNotificationsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/ViewSubmissionsController.scala
+++ b/app/controllers/ViewSubmissionsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/AuthenticatedAction.scala
+++ b/app/controllers/actions/AuthenticatedAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/actions/JourneyRefiner.scala
+++ b/app/controllers/actions/JourneyRefiner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/AssociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/AssociateUCRConfirmationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/AssociateUCRController.scala
+++ b/app/controllers/consolidations/AssociateUCRController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/AssociateUCRSummaryController.scala
+++ b/app/controllers/consolidations/AssociateUCRSummaryController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/DisassociateUCRController.scala
+++ b/app/controllers/consolidations/DisassociateUCRController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/DisassociateUCRSummaryController.scala
+++ b/app/controllers/consolidations/DisassociateUCRSummaryController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/MucrOptionsController.scala
+++ b/app/controllers/consolidations/MucrOptionsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/ShutMUCRConfirmationController.scala
+++ b/app/controllers/consolidations/ShutMUCRConfirmationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/ShutMucrController.scala
+++ b/app/controllers/consolidations/ShutMucrController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/consolidations/ShutMucrSummaryController.scala
+++ b/app/controllers/consolidations/ShutMucrSummaryController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/exchanges/AuthenticatedRequest.scala
+++ b/app/controllers/exchanges/AuthenticatedRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/exchanges/JourneyRequest.scala
+++ b/app/controllers/exchanges/JourneyRequest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/ArrivalReferenceController.scala
+++ b/app/controllers/movements/ArrivalReferenceController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/ConsignmentReferencesController.scala
+++ b/app/controllers/movements/ConsignmentReferencesController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/GoodsDepartedController.scala
+++ b/app/controllers/movements/GoodsDepartedController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/LocationController.scala
+++ b/app/controllers/movements/LocationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/MovementConfirmationController.scala
+++ b/app/controllers/movements/MovementConfirmationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/MovementDetailsController.scala
+++ b/app/controllers/movements/MovementDetailsController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/MovementSummaryController.scala
+++ b/app/controllers/movements/MovementSummaryController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/movements/TransportController.scala
+++ b/app/controllers/movements/TransportController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/controllers/storage/FlashKeys.scala
+++ b/app/controllers/storage/FlashKeys.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/ArrivalDetails.scala
+++ b/app/forms/ArrivalDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/ArrivalReference.scala
+++ b/app/forms/ArrivalReference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/AssociateUcr.scala
+++ b/app/forms/AssociateUcr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/Choice.scala
+++ b/app/forms/Choice.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/ConsignmentReferences.scala
+++ b/app/forms/ConsignmentReferences.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/DepartureDetails.scala
+++ b/app/forms/DepartureDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/DisassociateUcr.scala
+++ b/app/forms/DisassociateUcr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/EnhancedMapping.scala
+++ b/app/forms/EnhancedMapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/GoodsDeparted.scala
+++ b/app/forms/GoodsDeparted.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/Location.scala
+++ b/app/forms/Location.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/MovementBuilder.scala
+++ b/app/forms/MovementBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/MovementDetails.scala
+++ b/app/forms/MovementDetails.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/MucrOptions.scala
+++ b/app/forms/MucrOptions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/ShutMucr.scala
+++ b/app/forms/ShutMucr.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/Transport.scala
+++ b/app/forms/Transport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/common/Date.scala
+++ b/app/forms/common/Date.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/common/Time.scala
+++ b/app/forms/common/Time.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/forms/providers/TransportFormProvider.scala
+++ b/app/forms/providers/TransportFormProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/metrics/MovementsMetrics.scala
+++ b/app/metrics/MovementsMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/ReturnToStartException.scala
+++ b/app/models/ReturnToStartException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/UcrBlock.scala
+++ b/app/models/UcrBlock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/cache/Answers.scala
+++ b/app/models/cache/Answers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/cache/Cache.scala
+++ b/app/models/cache/Cache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/cache/JourneyType.scala
+++ b/app/models/cache/JourneyType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/notifications/Entry.scala
+++ b/app/models/notifications/Entry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/notifications/EntryStatus.scala
+++ b/app/models/notifications/EntryStatus.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/notifications/GoodsItem.scala
+++ b/app/models/notifications/GoodsItem.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/notifications/NotificationFrontendModel.scala
+++ b/app/models/notifications/NotificationFrontendModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/notifications/ResponseType.scala
+++ b/app/models/notifications/ResponseType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/submissions/ActionType.scala
+++ b/app/models/submissions/ActionType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/submissions/Submission.scala
+++ b/app/models/submissions/Submission.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/HtmlTableRow.scala
+++ b/app/models/viewmodels/HtmlTableRow.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/ActionCode.scala
+++ b/app/models/viewmodels/decoder/ActionCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/CHIEFError.scala
+++ b/app/models/viewmodels/decoder/CHIEFError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/CRCCode.scala
+++ b/app/models/viewmodels/decoder/CRCCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/CodeWithMessageKey.scala
+++ b/app/models/viewmodels/decoder/CodeWithMessageKey.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/Decoder.scala
+++ b/app/models/viewmodels/decoder/Decoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/ICSCode.scala
+++ b/app/models/viewmodels/decoder/ICSCode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/ILEError.scala
+++ b/app/models/viewmodels/decoder/ILEError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/ROECode.scala
+++ b/app/models/viewmodels/decoder/ROECode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/decoder/SOECode.scala
+++ b/app/models/viewmodels/decoder/SOECode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/MovementTotalsResponseType.scala
+++ b/app/models/viewmodels/notificationspage/MovementTotalsResponseType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/NotificationPageSingleElementFactory.scala
+++ b/app/models/viewmodels/notificationspage/NotificationPageSingleElementFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/NotificationsPageSingleElement.scala
+++ b/app/models/viewmodels/notificationspage/NotificationsPageSingleElement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/ControlResponseAcknowledgedConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/ControlResponseAcknowledgedConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/ControlResponseBlockedConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/ControlResponseBlockedConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/ControlResponseRejectedConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/ControlResponseRejectedConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/EMRResponseConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/EMRResponseConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/ERSResponseConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/ERSResponseConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/MovementResponseConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/MovementResponseConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/NotificationPageSingleElementConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/NotificationPageSingleElementConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/ResponseConverterProvider.scala
+++ b/app/models/viewmodels/notificationspage/converters/ResponseConverterProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/models/viewmodels/notificationspage/converters/UnknownResponseConverter.scala
+++ b/app/models/viewmodels/notificationspage/converters/UnknownResponseConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/modules/DateTimeModule.scala
+++ b/app/modules/DateTimeModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/modules/MessagesApiProviderModule.scala
+++ b/app/modules/MessagesApiProviderModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/repositories/CacheRepository.scala
+++ b/app/repositories/CacheRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/Countries.scala
+++ b/app/services/Countries.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/audit/AuditService.scala
+++ b/app/services/audit/AuditService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/services/audit/AuditType.scala
+++ b/app/services/audit/AuditType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/FieldValidator.scala
+++ b/app/utils/FieldValidator.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/utils/internationalisation/MovementsMessagesApiProvider.scala
+++ b/app/utils/internationalisation/MovementsMessagesApiProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/Title.scala
+++ b/app/views/Title.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/arrival_details.scala.html
+++ b/app/views/arrival_details.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/arrival_reference.scala.html
+++ b/app/views/arrival_reference.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/associate_ucr.scala.html
+++ b/app/views/associate_ucr.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/associate_ucr_confirmation.scala.html
+++ b/app/views/associate_ucr_confirmation.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/associate_ucr_summary.scala.html
+++ b/app/views/associate_ucr_summary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/button_link.scala.html
+++ b/app/views/components/button_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/code_explanation.scala.html
+++ b/app/views/components/code_explanation.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/confirmation_status_info.scala.html
+++ b/app/views/components/confirmation_status_info.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/error_summary.scala.html
+++ b/app/views/components/error_summary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/fields/RadioOption.scala
+++ b/app/views/components/fields/RadioOption.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/heading.scala.html
+++ b/app/views/components/heading.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/highlight_box_with_reference.scala.html
+++ b/app/views/components/highlight_box_with_reference.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/input_date.scala.html
+++ b/app/views/components/input_date.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/input_radio.scala.html
+++ b/app/views/components/input_radio.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/input_text.scala.html
+++ b/app/views/components/input_text.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/input_time.scala.html
+++ b/app/views/components/input_time.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/notification_errors.scala.html
+++ b/app/views/components/notification_errors.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/notifications_single_element.scala.html
+++ b/app/views/components/notifications_single_element.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/page_title.scala.html
+++ b/app/views/components/page_title.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/paragraph.scala.html
+++ b/app/views/components/paragraph.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/submit_button.scala.html
+++ b/app/views/components/submit_button.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/summary_list.scala.html
+++ b/app/views/components/summary_list.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/components/table_row_no_change_link.scala.html
+++ b/app/views/components/table_row_no_change_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/consignment_references.scala.html
+++ b/app/views/consignment_references.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/departure_details.scala.html
+++ b/app/views/departure_details.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/disassociate_ucr.scala.html
+++ b/app/views/disassociate_ucr.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/disassociate_ucr_confirmation.scala.html
+++ b/app/views/disassociate_ucr_confirmation.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/disassociate_ucr_summary.scala.html
+++ b/app/views/disassociate_ucr_summary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/error.scala.html
+++ b/app/views/error.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/goods_departed.scala.html
+++ b/app/views/goods_departed.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/location.scala.html
+++ b/app/views/location.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/movement_confirmation_page.scala.html
+++ b/app/views/movement_confirmation_page.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/mucr_options.scala.html
+++ b/app/views/mucr_options.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/shut_mucr.scala.html
+++ b/app/views/shut_mucr.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/shut_mucr_confirmation.scala.html
+++ b/app/views/shut_mucr_confirmation.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/shut_mucr_summary.scala.html
+++ b/app/views/shut_mucr_summary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/summary/arrival_summary_page.scala.html
+++ b/app/views/summary/arrival_summary_page.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/summary/departure_summary_page.scala.html
+++ b/app/views/summary/departure_summary_page.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/summary/retrospective_arrival_summary_page.scala.html
+++ b/app/views/summary/retrospective_arrival_summary_page.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/templates/govuk_internal_template.scala.html
+++ b/app/views/templates/govuk_internal_template.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/templates/govuk_wrapper.scala.html
+++ b/app/views/templates/govuk_wrapper.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/templates/main_template.scala.html
+++ b/app/views/templates/main_template.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/transport.scala.html
+++ b/app/views/transport.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/unauthorized.scala.html
+++ b/app/views/unauthorized.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/view_notifications.scala.html
+++ b/app/views/view_notifications.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/views/view_submissions.scala.html
+++ b/app/views/view_submissions.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2019 HM Revenue & Customs
+# Copyright 2020 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,16 +5,15 @@ object AppDependencies {
 
   val compile = Seq(
     "uk.gov.hmrc" %% "simple-reactivemongo"          % "7.22.0-play-26",
-    "uk.gov.hmrc" %% "govuk-template"                % "5.42.0-play-26",
-    "uk.gov.hmrc" %% "play-json-union-formatter"     % "1.5.0",
+    "uk.gov.hmrc" %% "govuk-template"                % "5.48.0-play-26",
+    "uk.gov.hmrc" %% "play-json-union-formatter"     % "1.7.0",
     "uk.gov.hmrc" %% "play-ui"                       % "8.5.0-play-26",
-    "uk.gov.hmrc" %% "bootstrap-play-26"             % "1.1.0",
-    "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.1.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26"             % "1.3.0",
+    "uk.gov.hmrc" %% "play-conditional-form-mapping" % "1.2.0-play-26",
     "com.github.tototoshi" %% "scala-csv" % "1.3.6"
   ).map(_.withSources())
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.1.0" % Test classifier "tests",
     "org.scalatest"           %% "scalatest"                % "3.0.8"                 % "test, it",
     "org.jsoup"               %  "jsoup"                    % "1.10.2"                % "test, it",
     "com.typesafe.play"       %% "play-test"                % current                 % "test, it",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.4.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -13,7 +13,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/test/it/AssociateUcrSpec.scala
+++ b/test/it/AssociateUcrSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, matchingJsonPath, verify}
 import forms.MucrOptions.CreateOrAddValues.Create
 import forms.{AssociateKind, AssociateUcr, MucrOptions}
 import models.cache.AssociateUcrAnswers
@@ -117,7 +117,7 @@ class AssociateUcrSpec extends IntegrationSpec {
         verify(
           postRequestedForConsolidation()
             .withRequestBody(
-              equalTo(
+              equalToJson(
                 """{"providerId":"pid","eori":"GB1234567890","mucr":"GB/123-12345","ucr":"GB/321-54321","consolidationType":"ASSOCIATE_MUCR"}"""
               )
             )

--- a/test/it/DissociateUcrSpec.scala
+++ b/test/it/DissociateUcrSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, matchingJsonPath, verify}
 import forms.{DisassociateKind, DisassociateUcr}
 import models.cache.DisassociateUcrAnswers
 import play.api.test.Helpers._
@@ -92,7 +92,9 @@ class DissociateUcrSpec extends IntegrationSpec {
         theCacheFor("pid") mustBe None
         verify(
           postRequestedForConsolidation()
-            .withRequestBody(equalTo("""{"providerId":"pid","eori":"GB1234567890","ucr":"GB/321-54321","consolidationType":"DISASSOCIATE_MUCR"}"""))
+            .withRequestBody(
+              equalToJson("""{"providerId":"pid","eori":"GB1234567890","ucr":"GB/321-54321","consolidationType":"DISASSOCIATE_MUCR"}""")
+            )
         )
         verifyEventually(
           postRequestedForAudit()

--- a/test/it/ShutMucrSpec.scala
+++ b/test/it/ShutMucrSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, matchingJsonPath, verify}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalTo, equalToJson, matchingJsonPath, verify}
 import forms.ShutMucr
 import models.cache.ShutMucrAnswers
 import play.api.test.Helpers._
@@ -84,7 +84,7 @@ class ShutMucrSpec extends IntegrationSpec {
         theCacheFor("pid") mustBe None
         verify(
           postRequestedForConsolidation()
-            .withRequestBody(equalTo("""{"providerId":"pid","eori":"GB1234567890","mucr":"GB/123-12345","consolidationType":"SHUT_MUCR"}"""))
+            .withRequestBody(equalToJson("""{"providerId":"pid","eori":"GB1234567890","mucr":"GB/123-12345","consolidationType":"SHUT_MUCR"}"""))
         )
         verifyEventually(
           postRequestedForAudit()

--- a/test/unit/config/AppConfigSpec.scala
+++ b/test/unit/config/AppConfigSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/config/ErrorHandlerSpec.scala
+++ b/test/unit/config/ErrorHandlerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/connectors/CustomsDeclareExportsMovementsConnectorSpec.scala
+++ b/test/unit/connectors/CustomsDeclareExportsMovementsConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/connectors/CustomsDeclareExportsMovementsConnectorSpec.scala
+++ b/test/unit/connectors/CustomsDeclareExportsMovementsConnectorSpec.scala
@@ -89,7 +89,7 @@ class CustomsDeclareExportsMovementsConnectorSpec extends ConnectorSpec with Moc
 
       verify(
         postRequestedFor(urlEqualTo("/consolidation"))
-          .withRequestBody(equalTo("""{"providerId":"provider-id","eori":"eori","ucr":"ucr","consolidationType":"DISASSOCIATE_DUCR"}"""))
+          .withRequestBody(equalToJson("""{"ucr":"ucr","providerId":"provider-id","consolidationType":"DISASSOCIATE_DUCR", "eori":"eori"}"""))
       )
     }
   }

--- a/test/unit/controllers/CSRFSupport.scala
+++ b/test/unit/controllers/CSRFSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -31,7 +31,6 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
 import testdata.CommonTestData.providerId
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.choice_page
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/ControllerLayerSpec.scala
+++ b/test/unit/controllers/ControllerLayerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/ControllerLayerSpec.scala
+++ b/test/unit/controllers/ControllerLayerSpec.scala
@@ -24,21 +24,22 @@ import controllers.exchanges.{AuthenticatedRequest, JourneyRequest, Operator}
 import models.cache.Answers
 import models.cache.JourneyType.JourneyType
 import org.scalatest.BeforeAndAfterEach
-import play.api.i18n.Messages
+import play.api.http.{DefaultFileMimeTypes, FileMimeTypes, FileMimeTypesConfiguration}
+import play.api.i18n.{Langs, Messages, MessagesApi}
 import play.api.libs.json.Writes
 import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.api.test.NoMaterializer
 import play.api.{Configuration, Environment}
 import play.twirl.api.Html
 import repositories.CacheRepository
 import testdata.CommonTestData.providerId
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.ViewTemplates
 import views.html.unauthorized
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 abstract class ControllerLayerSpec extends UnitSpec with ViewTemplates with BeforeAndAfterEach with CSRFSupport {
 
@@ -93,4 +94,21 @@ abstract class ControllerLayerSpec extends UnitSpec with ViewTemplates with Befo
       Future.successful(Left(Results.Forbidden))
   }
 
+  def stubMessagesControllerComponents(
+    bodyParser: BodyParser[AnyContent] = stubBodyParser(AnyContentAsEmpty),
+    playBodyParsers: PlayBodyParsers = stubPlayBodyParsers(NoMaterializer),
+    messagesApi: MessagesApi = stubMessagesApi(),
+    langs: Langs = stubLangs(),
+    fileMimeTypes: FileMimeTypes = new DefaultFileMimeTypes(FileMimeTypesConfiguration()),
+    executionContext: ExecutionContext = ExecutionContext.global
+  ): MessagesControllerComponents =
+    DefaultMessagesControllerComponents(
+      new DefaultMessagesActionBuilderImpl(bodyParser, messagesApi)(executionContext),
+      DefaultActionBuilder(bodyParser)(executionContext),
+      playBodyParsers,
+      messagesApi,
+      langs,
+      fileMimeTypes,
+      executionContext
+    )
 }

--- a/test/unit/controllers/ViewNotificationsControllerSpec.scala
+++ b/test/unit/controllers/ViewNotificationsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/ViewNotificationsControllerSpec.scala
+++ b/test/unit/controllers/ViewNotificationsControllerSpec.scala
@@ -30,7 +30,6 @@ import play.twirl.api.HtmlFormat
 import testdata.CommonTestData.{conversationId, providerId, validEori}
 import testdata.MovementsTestData.exampleSubmission
 import testdata.NotificationTestData.exampleNotificationFrontendModel
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.view_notifications
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/test/unit/controllers/ViewSubmissionsControllerSpec.scala
+++ b/test/unit/controllers/ViewSubmissionsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/ViewSubmissionsControllerSpec.scala
+++ b/test/unit/controllers/ViewSubmissionsControllerSpec.scala
@@ -31,7 +31,6 @@ import testdata.CommonTestData.{conversationId, conversationId_2, conversationId
 import testdata.MovementsTestData
 import testdata.MovementsTestData.exampleSubmission
 import testdata.NotificationTestData.exampleNotificationFrontendModel
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.view_submissions
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/actions/AuthenticatedActionSpec.scala
+++ b/test/unit/controllers/actions/AuthenticatedActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/actions/AuthenticatedActionSpec.scala
+++ b/test/unit/controllers/actions/AuthenticatedActionSpec.scala
@@ -33,7 +33,6 @@ import uk.gov.hmrc.auth.core.AuthProvider.PrivilegedApplication
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.{Credentials, Retrieval}
 import uk.gov.hmrc.auth.core.{AuthProvider, AuthProviders, AuthorisationException, Enrolment, NoActiveSession}
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.unauthorized
 
 import scala.concurrent.Future

--- a/test/unit/controllers/actions/JourneyRefinerSpec.scala
+++ b/test/unit/controllers/actions/JourneyRefinerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/actions/TypedJourneyRefinerTest.scala
+++ b/test/unit/controllers/actions/TypedJourneyRefinerTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
@@ -23,7 +23,6 @@ import models.ReturnToStartException
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.associate_ucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/consolidations/AssociateUCRControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/AssociateUCRControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRControllerSpec.scala
@@ -26,7 +26,6 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.associate_ucr
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
@@ -26,7 +26,6 @@ import org.mockito.Mockito.{reset, verify, when}
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.SubmissionService
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.associate_ucr_summary
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
@@ -23,7 +23,6 @@ import models.ReturnToStartException
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.disassociate_ucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/consolidations/DisassociateUCRControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/DisassociateUCRControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRControllerSpec.scala
@@ -25,7 +25,6 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.disassociate_ucr
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/consolidations/DisassociateUCRSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRSummaryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/DisassociateUCRSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRSummaryControllerSpec.scala
@@ -30,7 +30,6 @@ import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.SubmissionService
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.disassociate_ucr_summary
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
+++ b/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
+++ b/test/unit/controllers/consolidations/MucrOptionsControllerSpec.scala
@@ -28,7 +28,6 @@ import play.api.libs.json.{JsString, Json}
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.mucr_options
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
@@ -23,7 +23,6 @@ import models.ReturnToStartException
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.shut_mucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/consolidations/ShutMucrControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMucrControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/ShutMucrControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMucrControllerSpec.scala
@@ -27,7 +27,6 @@ import play.api.libs.json.{JsString, Json}
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.shut_mucr
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/consolidations/ShutMucrSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMucrSummaryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/consolidations/ShutMucrSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMucrSummaryControllerSpec.scala
@@ -26,7 +26,6 @@ import org.mockito.Mockito.{reset, verify, when}
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.{MockCache, SubmissionService}
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.shut_mucr_summary
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/movements/ArrivalReferenceControllerSpec.scala
+++ b/test/unit/controllers/movements/ArrivalReferenceControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/ArrivalReferenceControllerSpec.scala
+++ b/test/unit/controllers/movements/ArrivalReferenceControllerSpec.scala
@@ -27,7 +27,6 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.arrival_reference
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/movements/ConsignmentReferencesControllerSpec.scala
+++ b/test/unit/controllers/movements/ConsignmentReferencesControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/ConsignmentReferencesControllerSpec.scala
+++ b/test/unit/controllers/movements/ConsignmentReferencesControllerSpec.scala
@@ -27,7 +27,6 @@ import play.api.libs.json.{JsObject, JsString}
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.consignment_references
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/movements/GoodsDepartedControllerSpec.scala
+++ b/test/unit/controllers/movements/GoodsDepartedControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/GoodsDepartedControllerSpec.scala
+++ b/test/unit/controllers/movements/GoodsDepartedControllerSpec.scala
@@ -28,7 +28,6 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.goods_departed
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/movements/LocationControllerSpec.scala
+++ b/test/unit/controllers/movements/LocationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/LocationControllerSpec.scala
+++ b/test/unit/controllers/movements/LocationControllerSpec.scala
@@ -27,7 +27,6 @@ import play.api.libs.json.Json
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.location
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/movements/MovementConfirmationControllerSpec.scala
+++ b/test/unit/controllers/movements/MovementConfirmationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/MovementConfirmationControllerSpec.scala
+++ b/test/unit/controllers/movements/MovementConfirmationControllerSpec.scala
@@ -25,7 +25,6 @@ import models.cache.JourneyType
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.movement_confirmation_page
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/movements/MovementDetailsControllerSpec.scala
+++ b/test/unit/controllers/movements/MovementDetailsControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/MovementDetailsControllerSpec.scala
+++ b/test/unit/controllers/movements/MovementDetailsControllerSpec.scala
@@ -31,7 +31,6 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
 import testdata.MovementsTestData
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.{arrival_details, departure_details}
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/controllers/movements/MovementSummaryControllerSpec.scala
+++ b/test/unit/controllers/movements/MovementSummaryControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/MovementSummaryControllerSpec.scala
+++ b/test/unit/controllers/movements/MovementSummaryControllerSpec.scala
@@ -28,7 +28,6 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.{MockCache, SubmissionService}
 import testdata.CommonTestData.correctUcr
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.movement_confirmation_page
 import views.html.summary.{arrival_summary_page, departure_summary_page, retrospective_arrival_summary_page}
 

--- a/test/unit/controllers/movements/TransportControllerSpec.scala
+++ b/test/unit/controllers/movements/TransportControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/controllers/movements/TransportControllerSpec.scala
+++ b/test/unit/controllers/movements/TransportControllerSpec.scala
@@ -30,7 +30,6 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import services.MockCache
 import testdata.CommonTestData.providerId
-import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.transport
 
 import scala.concurrent.ExecutionContext.global

--- a/test/unit/forms/ArrivalDetailsSpec.scala
+++ b/test/unit/forms/ArrivalDetailsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/ChoiceSpec.scala
+++ b/test/unit/forms/ChoiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/ConsignmentReferenceTypeSpec.scala
+++ b/test/unit/forms/ConsignmentReferenceTypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/ConsignmentReferencesSpec.scala
+++ b/test/unit/forms/ConsignmentReferencesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/DepartureDetailsSpec.scala
+++ b/test/unit/forms/DepartureDetailsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/GoodsDepartedSpec.scala
+++ b/test/unit/forms/GoodsDepartedSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/LocationSpec.scala
+++ b/test/unit/forms/LocationSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/MovementBuilderSpec.scala
+++ b/test/unit/forms/MovementBuilderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/MovementDetailsSpec.scala
+++ b/test/unit/forms/MovementDetailsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/MucrOptionsSpec.scala
+++ b/test/unit/forms/MucrOptionsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/ShutMucrSpec.scala
+++ b/test/unit/forms/ShutMucrSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/TransportSpec.scala
+++ b/test/unit/forms/TransportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/common/DateSpec.scala
+++ b/test/unit/forms/common/DateSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/common/TimeSpec.scala
+++ b/test/unit/forms/common/TimeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/forms/providers/TransportFormProviderSpec.scala
+++ b/test/unit/forms/providers/TransportFormProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/cache/AnswersSpec.scala
+++ b/test/unit/models/cache/AnswersSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/notifications/ResponseTypeSpec.scala
+++ b/test/unit/models/notifications/ResponseTypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/submissions/ActionTypeSpec.scala
+++ b/test/unit/models/submissions/ActionTypeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/ActionCodeSpec.scala
+++ b/test/unit/models/viewmodels/decoder/ActionCodeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/CHIEFErrorSpec.scala
+++ b/test/unit/models/viewmodels/decoder/CHIEFErrorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/CRCCodeSpec.scala
+++ b/test/unit/models/viewmodels/decoder/CRCCodeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/DecoderSpec.scala
+++ b/test/unit/models/viewmodels/decoder/DecoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/ICSCodeSpec.scala
+++ b/test/unit/models/viewmodels/decoder/ICSCodeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/ILEErrorSpec.scala
+++ b/test/unit/models/viewmodels/decoder/ILEErrorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/ROECodeSpec.scala
+++ b/test/unit/models/viewmodels/decoder/ROECodeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/decoder/SOECodeSpec.scala
+++ b/test/unit/models/viewmodels/decoder/SOECodeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/NotificationPageSingleElementFactorySpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/NotificationPageSingleElementFactorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/ControlResponseAcknowledgedConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/ControlResponseAcknowledgedConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/ControlResponseBlockedConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/ControlResponseBlockedConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/ControlResponseRejectedConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/ControlResponseRejectedConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/EMRResponseConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/EMRResponseConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/ERSResponseConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/ERSResponseConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/MovementResponseConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/MovementResponseConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/ResponseConverterProviderSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/ResponseConverterProviderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/models/viewmodels/notificationspage/converters/UnknownResponseConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/UnknownResponseConverterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/services/CountriesSpec.scala
+++ b/test/unit/services/CountriesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/services/MockCache.scala
+++ b/test/unit/services/MockCache.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/services/SubmissionServiceSpec.scala
+++ b/test/unit/services/SubmissionServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/services/audit/AuditServiceSpec.scala
+++ b/test/unit/services/audit/AuditServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/utils/DateTimeTestModule.scala
+++ b/test/unit/utils/DateTimeTestModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/utils/FieldValidatorSpec.scala
+++ b/test/unit/utils/FieldValidatorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/ChoicePageViewSpec.scala
+++ b/test/unit/views/ChoicePageViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/SubmissionsViewSpec.scala
+++ b/test/unit/views/SubmissionsViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/ViewMatchers.scala
+++ b/test/unit/views/ViewMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/ViewNotificationsViewSpec.scala
+++ b/test/unit/views/ViewNotificationsViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/ViewSpec.scala
+++ b/test/unit/views/ViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/ViewTemplates.scala
+++ b/test/unit/views/ViewTemplates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/consolidations/AssociateUCRSummaryViewSpec.scala
+++ b/test/unit/views/consolidations/AssociateUCRSummaryViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/consolidations/AssociateUcrViewSpec.scala
+++ b/test/unit/views/consolidations/AssociateUcrViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/consolidations/ShutMucrConfirmationViewSpec.scala
+++ b/test/unit/views/consolidations/ShutMucrConfirmationViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/consolidations/ShutMucrSummaryViewSpec.scala
+++ b/test/unit/views/consolidations/ShutMucrSummaryViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/consolidations/ShutMucrViewSpec.scala
+++ b/test/unit/views/consolidations/ShutMucrViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/disassociate_ucr/DisassociateUcrConfirmationViewSpec.scala
+++ b/test/unit/views/disassociate_ucr/DisassociateUcrConfirmationViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/disassociate_ucr/DisassociateUcrSummaryViewSpec.scala
+++ b/test/unit/views/disassociate_ucr/DisassociateUcrSummaryViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/disassociate_ucr/DisassociateUcrViewSpec.scala
+++ b/test/unit/views/disassociate_ucr/DisassociateUcrViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/ArrivalDetailsViewSpec.scala
+++ b/test/unit/views/movement/ArrivalDetailsViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/ArrivalReferenceViewSpec.scala
+++ b/test/unit/views/movement/ArrivalReferenceViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/ArrivalSummaryViewSpec.scala
+++ b/test/unit/views/movement/ArrivalSummaryViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/ConsignmentReferenceViewSpec.scala
+++ b/test/unit/views/movement/ConsignmentReferenceViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/DepartureDetailsViewSpec.scala
+++ b/test/unit/views/movement/DepartureDetailsViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/DepartureSummaryViewSpec.scala
+++ b/test/unit/views/movement/DepartureSummaryViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/GoodsDepartedViewSpec.scala
+++ b/test/unit/views/movement/GoodsDepartedViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/LocationViewSpec.scala
+++ b/test/unit/views/movement/LocationViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/MovementConfirmationArrivalViewSpec.scala
+++ b/test/unit/views/movement/MovementConfirmationArrivalViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/MovementConfirmationDepartureViewSpec.scala
+++ b/test/unit/views/movement/MovementConfirmationDepartureViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/MovementConfirmationRetrospectiveArrivalViewSpec.scala
+++ b/test/unit/views/movement/MovementConfirmationRetrospectiveArrivalViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/RetrospectiveArrivalSummaryViewSpec.scala
+++ b/test/unit/views/movement/RetrospectiveArrivalSummaryViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/views/movement/TransportViewSpec.scala
+++ b/test/unit/views/movement/TransportViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/base/Injector.scala
+++ b/test/util/base/Injector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/base/UnitSpec.scala
+++ b/test/util/base/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/connectors/AuditWiremockTestServer.scala
+++ b/test/util/connectors/AuditWiremockTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/connectors/AuthWiremockTestServer.scala
+++ b/test/util/connectors/AuthWiremockTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/connectors/ConnectorSpec.scala
+++ b/test/util/connectors/ConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/connectors/MovementsBackendWiremockTestServer.scala
+++ b/test/util/connectors/MovementsBackendWiremockTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/connectors/WiremockTestServer.scala
+++ b/test/util/connectors/WiremockTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/controllers/MessagesStub.scala
+++ b/test/util/controllers/MessagesStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/matchers/FormMatchers.scala
+++ b/test/util/matchers/FormMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/metrics/MetricMatchers.scala
+++ b/test/util/metrics/MetricMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/metrics/MovementsMetricsStub.scala
+++ b/test/util/metrics/MovementsMetricsStub.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/repository/TestMongoDB.scala
+++ b/test/util/repository/TestMongoDB.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/testdata/CommonTestData.scala
+++ b/test/util/testdata/CommonTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/testdata/MovementsTestData.scala
+++ b/test/util/testdata/MovementsTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/testdata/NotificationTestData.scala
+++ b/test/util/testdata/NotificationTestData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/testdata/TestDataHelper.scala
+++ b/test/util/testdata/TestDataHelper.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
We're not able to use the newest version of sbt-plugin. Version 2.6.24 use akka version 2.5.25.
The last akka version that is compatible with reactive mongo is 2.5.23.
This is the reason that we need to use sbt-plugin 2.6.23.

Moreover I added stubMessagesControllerComponents to our project. After library upgrade I wasn't able to use one from bootstrap.
I think it's better to have small methods like this in our project instead of using this from different libraries.