### PR TITLE
CEDS-2098 - Associate UCR page

### DIFF
--- a/app/controllers/consolidations/AssociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/AssociateUCRConfirmationController.scala
@@ -17,9 +17,7 @@
 package controllers.consolidations
 
 import controllers.actions.AuthenticatedAction
-import controllers.storage.FlashKeys
 import javax.inject.{Inject, Singleton}
-import models.ReturnToStartException
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -36,9 +34,7 @@ class AssociateUCRConfirmationController @Inject()(
     extends FrontendController(mcc) with I18nSupport {
 
   def display: Action[AnyContent] = authenticate { implicit request =>
-    val kind = request.flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
-    val ucr = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
-    Ok(page(kind, ucr))
+    Ok(page())
   }
 
 }

--- a/app/controllers/consolidations/AssociateUCRSummaryController.scala
+++ b/app/controllers/consolidations/AssociateUCRSummaryController.scala
@@ -24,9 +24,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.SubmissionService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.{associate_ucr_confirmation, associate_ucr_summary}
-import play.api.mvc.Results.Redirect
-import controllers.storage.FlashKeys
+import views.html.associate_ucr_summary
 
 import scala.concurrent.ExecutionContext
 
@@ -48,11 +46,9 @@ class AssociateUCRSummaryController @Inject()(
 
   def submit(): Action[AnyContent] = (authenticate andThen getJourney).async { implicit request =>
     val answers = request.answersAs[AssociateUcrAnswers]
-    val associateUcr = answers.associateUcr.getOrElse(throw ReturnToStartException)
 
     submissionService.submit(request.providerId, answers).map { _ =>
       Redirect(controllers.consolidations.routes.AssociateUCRConfirmationController.display())
-        .flashing(FlashKeys.CONSOLIDATION_KIND -> associateUcr.kind.formValue, FlashKeys.UCR -> associateUcr.ucr)
     }
   }
 }

--- a/app/views/associate_ucr_confirmation.scala.html
+++ b/app/views/associate_ucr_confirmation.scala.html
@@ -14,33 +14,33 @@
  * limitations under the License.
  *@
 
-@import controllers.routes
-@import uk.gov.hmrc.play.views.html._
-@import controllers.storage.FlashKeys
 @import views.Title
-@import views.html.templates.main_template
+@import components.gds.gds_main_template
+@import components.gds.pageTitle
+@import uk.gov.hmrc.govukfrontend.views.html.components.govukInsetText
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.insettext.InsetText
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+@import views.html.components.gds.link
 
-@this(main_template: main_template)
+@this(
+        govukLayout: gds_main_template,
+        pageTitle: pageTitle,
+        govukInsetText: govukInsetText
+)
 
-@(associateUcrKind: String, ucr: String)(implicit request: Request[_], messages: Messages)
+@()(implicit request: Request[_], messages: Messages)
 
-@prefix = @{ s"associate.$associateUcrKind.confirmation" }
-@associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR)">@messages("association.confirmation.associateOrDepart.associate")</a>}
-@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure)">@messages("association.confirmation.associateOrDepart.depart")</a>}
+@gotoTimelineLink = {<a class="govuk-link" href="@routes.ViewSubmissionsController.displayPage()">@messages("movement.confirmation.notification.timeline.link")</a>}
 
-@main_template(title = Title(s"$prefix.tab.heading")) {
+@govukLayout(title = Title(s"movement.confirmation.title.ASSOCIATE_UCR")) {
 
-    @components.highlight_box_with_reference(
-        headingText = messages(s"$prefix.heading", ucr)
-    )
+    @pageTitle(text = messages(s"movement.confirmation.title.ASSOCIATE_UCR"), classes = "govuk-heading-xl")
 
-    @components.confirmation_status_info()
+    @govukInsetText(InsetText(
+        content = HtmlContent(messages("movement.confirmation.header")+"<br>"+messages("movement.confirmation.header.check", gotoTimelineLink))
+    ))
 
-    <h2 id="what-next">@messages("movement.confirmation.whatNext")</h2>
-
-    <div id="next-steps">
-        @Html(messages("association.confirmation.associateOrDepart", associateLink, shutMucrLink))
-    </div>
-
-    @components.button_link("site.backToStart", routes.ChoiceController.displayPage())
+    <p class="govuk-body">
+    @link(message = messages("movement.confirmation.redirect.link"), href = routes.ChoiceController.displayPage())
+    </p>
 }

--- a/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
@@ -16,10 +16,10 @@
 
 package controllers.consolidations
 
+import base.Injector
 import controllers.ControllerLayerSpec
 import controllers.actions.AuthenticatedAction
 import controllers.storage.FlashKeys
-import models.ReturnToStartException
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -27,9 +27,9 @@ import views.html.associate_ucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AssociateUCRConfirmationControllerSpec extends ControllerLayerSpec {
+class AssociateUCRConfirmationControllerSpec extends ControllerLayerSpec with Injector {
 
-  private val page = new associate_ucr_confirmation(main_template)
+  private val page = instanceOf[associate_ucr_confirmation]
 
   private def controller(auth: AuthenticatedAction) =
     new AssociateUCRConfirmationController(auth, stubMessagesControllerComponents(), page)
@@ -41,13 +41,7 @@ class AssociateUCRConfirmationControllerSpec extends ControllerLayerSpec {
       val result = controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.CONSOLIDATION_KIND -> "kind", FlashKeys.UCR -> "123"))
 
       status(result) mustBe Status.OK
-      contentAsHtml(result) mustBe page("kind", "123")
-    }
-
-    "return to start for missing params" in {
-      intercept[RuntimeException] {
-        await(controller(SuccessfulAuth()).display(get))
-      } mustBe ReturnToStartException
+      contentAsHtml(result) mustBe page()
     }
 
     "return 403 when unauthenticated" in {

--- a/test/unit/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRSummaryControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers.consolidations
 
 import controllers.ControllerLayerSpec
-import controllers.storage.FlashKeys
 import forms.{AssociateKind, AssociateUcr, MucrOptions}
 import models.ReturnToStartException
 import models.cache.AssociateUcrAnswers
@@ -99,18 +98,7 @@ class AssociateUCRSummaryControllerSpec extends ControllerLayerSpec {
 
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.consolidations.routes.AssociateUCRConfirmationController.display().url)
-      flash(result).get(FlashKeys.CONSOLIDATION_KIND) mustBe Some("ducr")
-      flash(result).get(FlashKeys.UCR) mustBe Some("123")
     }
 
-    "return to start" when {
-      "ucr is missing" in {
-        val cachedData = AssociateUcrAnswers(mucrOptions = Some(MucrOptions("123")))
-
-        intercept[RuntimeException] {
-          await(controller(cachedData).submit()(postRequest))
-        } mustBe ReturnToStartException
-      }
-    }
   }
 }

--- a/test/unit/views/associate_ucr/AssociateUCRConfirmationViewSpec.scala
+++ b/test/unit/views/associate_ucr/AssociateUCRConfirmationViewSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.associate_ucr
+
+import base.Injector
+import play.api.test.FakeRequest
+import views.ViewSpec
+import views.html.associate_ucr_confirmation
+
+class AssociateUCRConfirmationViewSpec extends ViewSpec with Injector {
+
+  private implicit val request = FakeRequest()
+  private val page = instanceOf[associate_ucr_confirmation]
+
+  "AssociateUCRConfirmationView" when {
+
+    "View is rendered" should {
+
+      "render title" in {
+
+        page().getTitle must containMessage("movement.confirmation.title.ASSOCIATE_UCR")
+      }
+
+      "render header" in {
+
+        page()
+          .getElementsByClass("govuk-heading-xl")
+          .first() must containMessage("movement.confirmation.title.ASSOCIATE_UCR")
+      }
+
+      "have 'notification timeline' link" in {
+        val inset = page().getElementsByClass("govuk-inset-text").first()
+        inset
+          .getElementsByClass("govuk-link")
+          .first() must haveHref(controllers.routes.ViewSubmissionsController.displayPage())
+      }
+
+      "have 'find another consignment' link" in {
+        page()
+          .getElementsByClass("govuk-link")
+          .get(1) must haveHref(controllers.routes.ChoiceController.displayPage())
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This is a feature branch to consolidate merges from all related page-specific branches:

* CEDS-2098-arrive (affects departure and retrospective arrival) - ok
* CEDS-2098-associate - ok
* CEDS-2098-disassociate - TODO
* CEDS-2098-shut - TODO
* CEDS-2098-clean - TODO

It is an alternative confirmation screen to implement in the internal service as a way of avoiding cases being closed when they shouldn't be.

Currently, NCH operators see the existing confirmation screen at the end of each movement request journey and believe that it means their request has been completed and accepted. As their request has only been submitted to DMS and the acceptance (or rejection) is asynchronous, this could be misleading.