### PR TITLE
CEDS-2098 - Disassociate UCR page

### DIFF
--- a/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
+++ b/app/controllers/consolidations/DisassociateUCRConfirmationController.scala
@@ -36,9 +36,7 @@ class DisassociateUCRConfirmationController @Inject()(
     extends FrontendController(mcc) with I18nSupport {
 
   def display: Action[AnyContent] = authenticate { implicit request =>
-    val kind = request.flash.get(FlashKeys.CONSOLIDATION_KIND).getOrElse(throw ReturnToStartException)
-    val ucr = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
-    Ok(page(kind, ucr))
+    Ok(page())
   }
 
 }

--- a/app/views/disassociate_ucr_confirmation.scala.html
+++ b/app/views/disassociate_ucr_confirmation.scala.html
@@ -14,31 +14,33 @@
  * limitations under the License.
  *@
 
-@import controllers.routes
 @import views.Title
-@import views.Title.NO_SECTION
-@import views.html.templates.main_template
+@import components.gds.gds_main_template
+@import components.gds.pageTitle
+@import uk.gov.hmrc.govukfrontend.views.html.components.govukInsetText
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.insettext.InsetText
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+@import views.html.components.gds.link
 
-@this(main_template: main_template)
+@this(
+        govukLayout: gds_main_template,
+        pageTitle: pageTitle,
+        govukInsetText: govukInsetText
+)
 
-@(kind: String, ucr: String)(implicit request: Request[_], messages: Messages)
+@()(implicit request: Request[_], messages: Messages)
 
-    @associateLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR)">@messages("disassociation.confirmation.associateOrShut.associate")</a>}
-    @shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR)">@messages("disassociation.confirmation.associateOrShut.shut")</a>}
+    @gotoTimelineLink = {<a class="govuk-link" href="@routes.ViewSubmissionsController.displayPage()">@messages("movement.confirmation.notification.timeline.link")</a>}
 
-    @main_template(title = Title("disassociate.ucr.confirmation.tab.heading", NO_SECTION, Seq(kind.toUpperCase))) {
+    @govukLayout(title = Title(s"movement.confirmation.title.DISSOCIATE_UCR")) {
 
-        @components.highlight_box_with_reference(
-            headingText = messages("disassociate.ucr.confirmation.heading", kind.toUpperCase, ucr)
-        )
+        @pageTitle(text = messages(s"movement.confirmation.title.DISSOCIATE_UCR"), classes = "govuk-heading-xl")
 
-        @components.confirmation_status_info()
+        @govukInsetText(InsetText(
+            content = HtmlContent(messages("movement.confirmation.header")+"<br>"+messages("movement.confirmation.header.check", gotoTimelineLink))
+        ))
 
-        <h2 id="what-next">@messages("movement.confirmation.whatNext")</h2>
-
-        <div id="next-steps">
-        @Html(messages("disassociation.confirmation.associateOrShut", associateLink, shutMucrLink))
-        </div>
-
-        @components.button_link("site.backToStart", controllers.routes.ChoiceController.displayPage())
+        <p class="govuk-body">
+        @link(message = messages("movement.confirmation.redirect.link"), href = routes.ChoiceController.displayPage())
+        </p>
     }

--- a/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/AssociateUCRConfirmationControllerSpec.scala
@@ -16,25 +16,29 @@
 
 package controllers.consolidations
 
-import base.Injector
 import controllers.ControllerLayerSpec
 import controllers.actions.AuthenticatedAction
 import controllers.storage.FlashKeys
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
 import views.html.associate_ucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class AssociateUCRConfirmationControllerSpec extends ControllerLayerSpec with Injector {
+class AssociateUCRConfirmationControllerSpec extends ControllerLayerSpec with MockitoSugar {
 
-  private val page = instanceOf[associate_ucr_confirmation]
+  private val page = mock[associate_ucr_confirmation]
 
   private def controller(auth: AuthenticatedAction) =
     new AssociateUCRConfirmationController(auth, stubMessagesControllerComponents(), page)
 
   "GET" should {
+    when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
     implicit val get = FakeRequest("GET", "/")
 
     "return 200 when authenticated" in {

--- a/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
@@ -16,10 +16,10 @@
 
 package controllers.consolidations
 
+import base.Injector
 import controllers.ControllerLayerSpec
 import controllers.actions.AuthenticatedAction
 import controllers.storage.FlashKeys
-import models.ReturnToStartException
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -27,9 +27,9 @@ import views.html.disassociate_ucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DisassociateUCRConfirmationControllerSpec extends ControllerLayerSpec {
+class DisassociateUCRConfirmationControllerSpec extends ControllerLayerSpec with Injector {
 
-  private val page = new disassociate_ucr_confirmation(main_template)
+  private val page = instanceOf[disassociate_ucr_confirmation]
 
   private def controller(auth: AuthenticatedAction) =
     new DisassociateUCRConfirmationController(auth, stubMessagesControllerComponents(), page)
@@ -41,21 +41,7 @@ class DisassociateUCRConfirmationControllerSpec extends ControllerLayerSpec {
       val result = controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.CONSOLIDATION_KIND -> "kind", FlashKeys.UCR -> "ucr"))
 
       status(result) mustBe Status.OK
-      contentAsHtml(result) mustBe page("kind", "ucr")
-    }
-
-    "return to start" when {
-      "missing ucr" in {
-        intercept[RuntimeException] {
-          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.UCR -> "ucr")))
-        } mustBe ReturnToStartException
-      }
-
-      "missing kind" in {
-        intercept[RuntimeException] {
-          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.CONSOLIDATION_KIND -> "kind")))
-        } mustBe ReturnToStartException
-      }
+      contentAsHtml(result) mustBe page()
     }
 
     "return 403 when unauthenticated" in {

--- a/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRConfirmationControllerSpec.scala
@@ -16,20 +16,23 @@
 
 package controllers.consolidations
 
-import base.Injector
 import controllers.ControllerLayerSpec
 import controllers.actions.AuthenticatedAction
 import controllers.storage.FlashKeys
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
 import views.html.disassociate_ucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class DisassociateUCRConfirmationControllerSpec extends ControllerLayerSpec with Injector {
+class DisassociateUCRConfirmationControllerSpec extends ControllerLayerSpec with MockitoSugar {
 
-  private val page = instanceOf[disassociate_ucr_confirmation]
+  private val page = mock[disassociate_ucr_confirmation]
 
   private def controller(auth: AuthenticatedAction) =
     new DisassociateUCRConfirmationController(auth, stubMessagesControllerComponents(), page)
@@ -38,6 +41,7 @@ class DisassociateUCRConfirmationControllerSpec extends ControllerLayerSpec with
     implicit val get = FakeRequest("GET", "/")
 
     "return 200 when authenticated" in {
+      when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
       val result = controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.CONSOLIDATION_KIND -> "kind", FlashKeys.UCR -> "ucr"))
 
       status(result) mustBe Status.OK

--- a/test/unit/views/disassociate_ucr/DisassociateUcrConfirmationViewSpec.scala
+++ b/test/unit/views/disassociate_ucr/DisassociateUcrConfirmationViewSpec.scala
@@ -16,42 +16,44 @@
 
 package views.disassociate_ucr
 
-import play.api.mvc.{AnyContentAsEmpty, Request}
+import base.Injector
 import play.api.test.FakeRequest
 import views.ViewSpec
 import views.html.disassociate_ucr_confirmation
 
-class DisassociateUcrConfirmationViewSpec extends ViewSpec {
+class DisassociateUcrConfirmationViewSpec extends ViewSpec with Injector {
 
-  private implicit val request: Request[AnyContentAsEmpty.type] = FakeRequest().withCSRFToken
-  private def page = new disassociate_ucr_confirmation(main_template)
+  private implicit val request = FakeRequest()
+  private val page = instanceOf[disassociate_ucr_confirmation]
 
-  "View" should {
-    val view = page("mucr", "ucr")
+  "DisassociateUCRConfirmationView" when {
 
-    "render title" in {
-      view.getTitle must containMessage("disassociate.ucr.confirmation.tab.heading", "MUCR", "ucr")
-    }
+    "View is rendered" should {
 
-    "render confirmation dialogue" in {
-      view.getElementById("highlight-box-heading") must containMessage("disassociate.ucr.confirmation.heading", "MUCR", "ucr")
-    }
+      "render title" in {
 
-    "have 'view requests' link" in {
-      val statusInfo = view.getElementById("status-info")
-      statusInfo.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.ViewSubmissions))
-    }
+        page().getTitle must containMessage("movement.confirmation.title.DISSOCIATE_UCR")
+      }
 
-    "have 'next steps' link" in {
-      val nextSteps = view.getElementById("next-steps")
+      "render header" in {
 
-      val associate = nextSteps.getElementsByTag("a").get(0)
-      associate must containMessage("disassociation.confirmation.associateOrShut.associate")
-      associate must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.AssociateUCR))
+        page()
+          .getElementsByClass("govuk-heading-xl")
+          .first() must containMessage("movement.confirmation.title.DISSOCIATE_UCR")
+      }
 
-      val shut = nextSteps.getElementsByTag("a").get(1)
-      shut must containMessage("disassociation.confirmation.associateOrShut.shut")
-      shut must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR))
+      "have 'notification timeline' link" in {
+        val inset = page().getElementsByClass("govuk-inset-text").first()
+        inset
+          .getElementsByClass("govuk-link")
+          .first() must haveHref(controllers.routes.ViewSubmissionsController.displayPage())
+      }
+
+      "have 'find another consignment' link" in {
+        page()
+          .getElementsByClass("govuk-link")
+          .get(1) must haveHref(controllers.routes.ChoiceController.displayPage())
+      }
     }
   }
 


### PR DESCRIPTION
This is a feature branch to consolidate merges from all related page-specific branches:

* CEDS-2098-arrive (affects departure and retrospective arrival) - ok
* CEDS-2098-associate - ok
* CEDS-2098-disassociate - ok
* CEDS-2098-shut - TODO
* CEDS-2098-clean - TODO

It is an alternative confirmation screen to implement in the internal service as a way of avoiding cases being closed when they shouldn't be.

Currently, NCH operators see the existing confirmation screen at the end of each movement request journey and believe that it means their request has been completed and accepted. As their request has only been submitted to DMS and the acceptance (or rejection) is asynchronous, this could be misleading.