### PR TITLE
CEDS-2098 - Shut MUCR page

### DIFF
--- a/app/controllers/consolidations/ShutMUCRConfirmationController.scala
+++ b/app/controllers/consolidations/ShutMUCRConfirmationController.scala
@@ -17,9 +17,7 @@
 package controllers.consolidations
 
 import controllers.actions.AuthenticatedAction
-import controllers.storage.FlashKeys
 import javax.inject.{Inject, Singleton}
-import models.ReturnToStartException
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -33,8 +31,7 @@ class ShutMUCRConfirmationController @Inject()(authenticate: AuthenticatedAction
 ) extends FrontendController(mcc) with I18nSupport {
 
   def display: Action[AnyContent] = authenticate { implicit request =>
-    val ucr = request.flash.get(FlashKeys.MUCR).getOrElse(throw ReturnToStartException)
-    Ok(page(ucr))
+    Ok(page())
   }
 
 }

--- a/app/views/shut_mucr_confirmation.scala.html
+++ b/app/views/shut_mucr_confirmation.scala.html
@@ -14,31 +14,33 @@
  * limitations under the License.
  *@
 
-@import controllers.routes
-@import controllers.storage.FlashKeys
 @import views.Title
-@import views.html.templates.main_template
+@import components.gds.gds_main_template
+@import components.gds.pageTitle
+@import uk.gov.hmrc.govukfrontend.views.html.components.govukInsetText
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.insettext.InsetText
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
+@import views.html.components.gds.link
 
-@this(main_template: main_template)
+@this(
+        govukLayout: gds_main_template,
+        pageTitle: pageTitle,
+        govukInsetText: govukInsetText
+)
 
-@(mucr: String)(implicit request: Request[_], messages: Messages)
+@()(implicit request: Request[_], messages: Messages)
 
-@shutMucrLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR)">@messages("shutMucr.confirmation.nextSteps.shutMucr")</a>}
-@departureLink = {<a href="@routes.ChoiceController.startSpecificJourney(forms.Choice.Departure)">@messages("shutMucr.confirmation.nextSteps.depart")</a>}
+@gotoTimelineLink = {<a class="govuk-link" href="@routes.ViewSubmissionsController.displayPage()">@messages("movement.confirmation.notification.timeline.link")</a>}
 
-@main_template(title = Title("shutMucr.confirmation.tab.heading")) {
+@govukLayout(title = Title(s"movement.confirmation.title.SHUT_MUCR")) {
 
-    @components.highlight_box_with_reference(
-        headingText = messages("shutMucr.confirmation.heading", mucr)
-    )
+    @pageTitle(text = messages(s"movement.confirmation.title.SHUT_MUCR"), classes = "govuk-heading-xl")
 
-    @components.confirmation_status_info()
+    @govukInsetText(InsetText(
+        content = HtmlContent(messages("movement.confirmation.header")+"<br>"+messages("movement.confirmation.header.check", gotoTimelineLink))
+    ))
 
-    <h2 id="what-next">@messages("movement.confirmation.whatNext")</h2>
-
-    <div id="next-steps">
-        @Html(messages("shutMucr.confirmation.nextSteps", shutMucrLink, departureLink))
-    </div>
-
-    @components.button_link("site.backToStart", routes.ChoiceController.displayPage())
+    <p class="govuk-body">
+    @link(message = messages("movement.confirmation.redirect.link"), href = routes.ChoiceController.displayPage())
+    </p>
 }

--- a/test/unit/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
+++ b/test/unit/controllers/consolidations/ShutMUCRConfirmationControllerSpec.scala
@@ -19,17 +19,20 @@ package controllers.consolidations
 import controllers.ControllerLayerSpec
 import controllers.actions.AuthenticatedAction
 import controllers.storage.FlashKeys
-import models.ReturnToStartException
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
 import views.html.shut_mucr_confirmation
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ShutMUCRConfirmationControllerSpec extends ControllerLayerSpec {
+class ShutMUCRConfirmationControllerSpec extends ControllerLayerSpec with MockitoSugar {
 
-  private val page = new shut_mucr_confirmation(main_template)
+  private val page = mock[shut_mucr_confirmation]
 
   private def controller(auth: AuthenticatedAction) =
     new ShutMUCRConfirmationController(auth, stubMessagesControllerComponents(), page)
@@ -38,16 +41,11 @@ class ShutMUCRConfirmationControllerSpec extends ControllerLayerSpec {
     implicit val get = FakeRequest("GET", "/")
 
     "return 200 when authenticated" in {
+      when(page.apply()(any(), any())).thenReturn(HtmlFormat.empty)
       val result = controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MUCR -> "123"))
 
       status(result) mustBe Status.OK
-      contentAsHtml(result) mustBe page("123")
-    }
-
-    "return to start for missing params" in {
-      intercept[RuntimeException] {
-        await(controller(SuccessfulAuth()).display(get))
-      } mustBe ReturnToStartException
+      contentAsHtml(result) mustBe page()
     }
 
     "return 403 when unauthenticated" in {

--- a/test/unit/views/consolidations/ShutMucrConfirmationViewSpec.scala
+++ b/test/unit/views/consolidations/ShutMucrConfirmationViewSpec.scala
@@ -16,53 +16,45 @@
 
 package views.consolidations
 
-import controllers.routes
-import models.cache.ShutMucrAnswers
+import base.Injector
+import play.api.test.FakeRequest
 import views.ViewSpec
 import views.html.shut_mucr_confirmation
 
-class ShutMucrConfirmationViewSpec extends ViewSpec {
+class ShutMucrConfirmationViewSpec extends ViewSpec with Injector {
 
-  private implicit val request = journeyRequest(ShutMucrAnswers())
+  private implicit val request = FakeRequest()
+  private val page = instanceOf[shut_mucr_confirmation]
 
-  private val page = new shut_mucr_confirmation(main_template)
-  private val mucr = "some-mucr"
+  "ShutMUCRConfirmationView" when {
 
-  "View" should {
+    "View is rendered" should {
 
-    "render title" in {
-      page(mucr).getTitle must containMessage("shutMucr.confirmation.tab.heading")
+      "render title" in {
+
+        page().getTitle must containMessage("movement.confirmation.title.SHUT_MUCR")
+      }
+
+      "render header" in {
+
+        page()
+          .getElementsByClass("govuk-heading-xl")
+          .first() must containMessage("movement.confirmation.title.SHUT_MUCR")
+      }
+
+      "have 'notification timeline' link" in {
+        val inset = page().getElementsByClass("govuk-inset-text").first()
+        inset
+          .getElementsByClass("govuk-link")
+          .first() must haveHref(controllers.routes.ViewSubmissionsController.displayPage())
+      }
+
+      "have 'find another consignment' link" in {
+        page()
+          .getElementsByClass("govuk-link")
+          .get(1) must haveHref(controllers.routes.ChoiceController.displayPage())
+      }
     }
-
-    "display page reference" in {
-
-      page(mucr).getElementById("highlight-box-heading") must containMessage("shutMucr.confirmation.heading", mucr)
-    }
-
-    "have what next section" in {
-
-      page(mucr).getElementById("what-next") must containMessage("movement.confirmation.whatNext")
-    }
-
-    "display 'Back to start page' button on page" in {
-
-      val backButton = page(mucr).getElementsByClass("button").first()
-
-      backButton must containMessage("site.backToStart")
-      backButton must haveHref(routes.ChoiceController.displayPage())
-    }
-
-    "have 'view requests' link" in {
-      val statusInfo = page(mucr).getElementById("status-info")
-      statusInfo.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.ViewSubmissions))
-    }
-
-    "have 'next steps' link" in {
-      val nextSteps = page(mucr).getElementById("next-steps")
-      nextSteps.getElementsByTag("a").get(0) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.ShutMUCR))
-      nextSteps.getElementsByTag("a").get(1) must haveHref(controllers.routes.ChoiceController.startSpecificJourney(forms.Choice.Departure))
-    }
-
   }
 
 }


### PR DESCRIPTION
This is a feature branch to consolidate merges from all related page-specific branches:

* CEDS-2098-arrive (affects departure and retrospective arrival) - ok
* CEDS-2098-associate - ok
* CEDS-2098-disassociate - ok
* CEDS-2098-shut - ok
* CEDS-2098-clean - TODO

It is an alternative confirmation screen to implement in the internal service as a way of avoiding cases being closed when they shouldn't be.

Currently, NCH operators see the existing confirmation screen at the end of each movement request journey and believe that it means their request has been completed and accepted. As their request has only been submitted to DMS and the acceptance (or rejection) is asynchronous, this could be misleading.