### PR TITLE
CEDS-2098 - Clean-up

### DIFF
--- a/app/controllers/movements/MovementConfirmationController.scala
+++ b/app/controllers/movements/MovementConfirmationController.scala
@@ -18,7 +18,6 @@ package controllers.movements
 
 import controllers.actions.AuthenticatedAction
 import controllers.storage.FlashKeys
-import forms.{ConsignmentReferenceType, ConsignmentReferences}
 import javax.inject.{Inject, Singleton}
 import models.ReturnToStartException
 import models.cache.JourneyType
@@ -36,9 +35,7 @@ class MovementConfirmationController @Inject()(authenticate: AuthenticatedAction
 
   def display: Action[AnyContent] = authenticate { implicit request =>
     val `type` = request.flash.get(FlashKeys.MOVEMENT_TYPE).map(JourneyType.withName).getOrElse(throw ReturnToStartException)
-    val kind = request.flash.get(FlashKeys.UCR_KIND).map(ConsignmentReferenceType.withName).getOrElse(throw ReturnToStartException)
-    val reference = request.flash.get(FlashKeys.UCR).getOrElse(throw ReturnToStartException)
-    Ok(page(`type`, ConsignmentReferences(kind, reference)))
+    Ok(page(`type`))
   }
 
 }

--- a/app/views/movement_confirmation_page.scala.html
+++ b/app/views/movement_confirmation_page.scala.html
@@ -30,8 +30,7 @@
     govukInsetText: govukInsetText
 )
 
-@* TODO remove consignmentReferences: ConsignmentReferences when all pages are done *@
-@(journeyType: JourneyType, consignmentReferences: ConsignmentReferences)(implicit request: Request[_], messages: Messages)
+@(journeyType: JourneyType)(implicit request: Request[_], messages: Messages)
 
 @gotoTimelineLink = {<a class="govuk-link" href="@routes.ViewSubmissionsController.displayPage()">@messages("movement.confirmation.notification.timeline.link")</a>}
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -173,7 +173,6 @@ movement.confirmation.header.check = Go to the {0} to check the status.
 movement.confirmation.notification.timeline.link = consignment’s notification timeline
 movement.confirmation.redirect.link = Find another consignment
 
-
 associate.heading = Add to MUCR {0}
 mucrOptions.heading = Add to MUCR
 mucrOptions.title = Create or enter a Master Consignment Reference (MUCR) to associate with
@@ -203,10 +202,9 @@ associate.ucr.summary.kind.ducr = DUCR
 associate.ucr.summary.addConsignment = Add consignment
 associate.ucr.summary.masterConsignment = To master consignment
 
-# TODO clean up next 3 lines after last page is done
+
 movement.confirmation.statusInfo = To check the status of this consignment, {0}.
 movement.confirmation.statusInfo.submissions = view requests
-movement.confirmation.whatNext = What do you want to do next? 
 
 associate.ducr.confirmation.tab.heading = Add DUCR request submitted
 associate.ducr.confirmation.heading = Request to associate DUCR {0} has been submitted

--- a/test/unit/controllers/movements/MovementConfirmationControllerSpec.scala
+++ b/test/unit/controllers/movements/MovementConfirmationControllerSpec.scala
@@ -16,58 +16,60 @@
 
 package controllers.movements
 
-import base.Injector
 import controllers.ControllerLayerSpec
 import controllers.actions.AuthenticatedAction
 import controllers.storage.FlashKeys
-import forms.{ConsignmentReferenceType, ConsignmentReferences}
+import forms.ConsignmentReferenceType
 import models.ReturnToStartException
 import models.cache.JourneyType
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
 import play.api.http.Status
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import services.MockCache
 import views.html.movement_confirmation_page
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class MovementConfirmationControllerSpec extends ControllerLayerSpec with Injector {
+class MovementConfirmationControllerSpec extends ControllerLayerSpec with MockCache {
 
-  private val page = instanceOf[movement_confirmation_page]
+  private val page = mock[movement_confirmation_page]
 
   private def controller(auth: AuthenticatedAction) =
     new MovementConfirmationController(auth, stubMessagesControllerComponents(), page)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+
+    when(page.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    reset(page)
+
+    super.afterEach()
+  }
 
   "GET" should {
     implicit val get = FakeRequest("GET", "/")
 
     "return 200 when authenticated" in {
       val result = controller(SuccessfulAuth())
-        .display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR_KIND -> "D", FlashKeys.UCR -> "123"))
+        .display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR_KIND -> "D"))
 
       status(result) mustBe Status.OK
-      contentAsHtml(result) mustBe page(JourneyType.ARRIVE, ConsignmentReferences(ConsignmentReferenceType.D, "123"))
+      contentAsHtml(result) mustBe page(JourneyType.ARRIVE)
     }
 
     "return to start" when {
       "journey type is missing" in {
         intercept[RuntimeException] {
-          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.UCR_KIND -> "kind", FlashKeys.UCR -> "123")))
+          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.UCR_KIND -> "kind")))
         } mustBe ReturnToStartException
       }
 
-      "ucr kind is missing" in {
-        intercept[RuntimeException] {
-          await(controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR -> "123")))
-        } mustBe ReturnToStartException
-      }
-
-      "ucr is missing" in {
-        intercept[RuntimeException] {
-          await(
-            controller(SuccessfulAuth()).display(get.withFlash(FlashKeys.MOVEMENT_TYPE -> JourneyType.ARRIVE.toString, FlashKeys.UCR_KIND -> "D"))
-          )
-        } mustBe ReturnToStartException
-      }
     }
 
     "return 403 when unauthenticated" in {

--- a/test/unit/views/movement/MovementConfirmationArrivalViewSpec.scala
+++ b/test/unit/views/movement/MovementConfirmationArrivalViewSpec.scala
@@ -17,7 +17,6 @@
 package views.movement
 
 import base.Injector
-import forms.{ConsignmentReferenceType, ConsignmentReferences}
 import models.cache.{ArrivalAnswers, JourneyType}
 import views.ViewSpec
 import views.html.movement_confirmation_page
@@ -26,7 +25,6 @@ class MovementConfirmationArrivalViewSpec extends ViewSpec with Injector {
 
   private implicit val request = journeyRequest(ArrivalAnswers())
 
-  private val consignmentReferences = ConsignmentReferences(ConsignmentReferenceType.D, "9GB12345678")
   private val page = instanceOf[movement_confirmation_page]
 
   "MovementConfirmationArrivalView" when {
@@ -35,25 +33,25 @@ class MovementConfirmationArrivalViewSpec extends ViewSpec with Injector {
 
       "render title" in {
 
-        page(JourneyType.ARRIVE, consignmentReferences).getTitle must containMessage("movement.confirmation.title.ARRIVE")
+        page(JourneyType.ARRIVE).getTitle must containMessage("movement.confirmation.title.ARRIVE")
       }
 
       "render header" in {
 
-        page(JourneyType.ARRIVE, consignmentReferences)
+        page(JourneyType.ARRIVE)
           .getElementsByClass("govuk-heading-xl")
           .first() must containMessage("movement.confirmation.title.ARRIVE")
       }
 
       "have 'notification timeline' link" in {
-        val inset = page(JourneyType.ARRIVE, consignmentReferences).getElementsByClass("govuk-inset-text").first()
+        val inset = page(JourneyType.ARRIVE).getElementsByClass("govuk-inset-text").first()
         inset
           .getElementsByClass("govuk-link")
           .first() must haveHref(controllers.routes.ViewSubmissionsController.displayPage())
       }
 
       "have 'find another consignment' link" in {
-        page(JourneyType.ARRIVE, consignmentReferences)
+        page(JourneyType.ARRIVE)
           .getElementsByClass("govuk-link")
           .get(1) must haveHref(controllers.routes.ChoiceController.displayPage())
       }

--- a/test/unit/views/movement/MovementConfirmationDepartureViewSpec.scala
+++ b/test/unit/views/movement/MovementConfirmationDepartureViewSpec.scala
@@ -17,7 +17,6 @@
 package views.movement
 
 import base.Injector
-import forms.{ConsignmentReferenceType, ConsignmentReferences}
 import models.cache.{DepartureAnswers, JourneyType}
 import views.ViewSpec
 import views.html.movement_confirmation_page
@@ -26,29 +25,28 @@ class MovementConfirmationDepartureViewSpec extends ViewSpec with Injector {
 
   private implicit val request = journeyRequest(DepartureAnswers())
 
-  private val consignmentReferences = ConsignmentReferences(ConsignmentReferenceType.D, "9GB12345678")
   private val page = instanceOf[movement_confirmation_page]
 
   "View" should {
     "render title" in {
-      page(JourneyType.DEPART, consignmentReferences).getTitle must containMessage("movement.confirmation.title.DEPART")
+      page(JourneyType.DEPART).getTitle must containMessage("movement.confirmation.title.DEPART")
     }
 
     "render page title" in {
-      page(JourneyType.DEPART, consignmentReferences)
+      page(JourneyType.DEPART)
         .getElementsByClass("govuk-heading-xl")
         .first() must containMessage("movement.confirmation.title.DEPART")
     }
 
     "have 'notification timeline' link" in {
-      val inset = page(JourneyType.DEPART, consignmentReferences).getElementsByClass("govuk-inset-text").first()
+      val inset = page(JourneyType.DEPART).getElementsByClass("govuk-inset-text").first()
       inset
         .getElementsByClass("govuk-link")
         .first() must haveHref(controllers.routes.ViewSubmissionsController.displayPage())
     }
 
     "have 'find another consignment' link" in {
-      page(JourneyType.DEPART, consignmentReferences)
+      page(JourneyType.DEPART)
         .getElementsByClass("govuk-link")
         .get(1) must haveHref(controllers.routes.ChoiceController.displayPage())
     }

--- a/test/unit/views/movement/MovementConfirmationRetrospectiveArrivalViewSpec.scala
+++ b/test/unit/views/movement/MovementConfirmationRetrospectiveArrivalViewSpec.scala
@@ -17,7 +17,6 @@
 package views.movement
 
 import base.Injector
-import forms.{ConsignmentReferenceType, ConsignmentReferences}
 import models.cache.{JourneyType, RetrospectiveArrivalAnswers}
 import views.ViewSpec
 import views.html.movement_confirmation_page
@@ -26,29 +25,28 @@ class MovementConfirmationRetrospectiveArrivalViewSpec extends ViewSpec with Inj
 
   private implicit val request = journeyRequest(RetrospectiveArrivalAnswers())
 
-  private val consignmentReferences = ConsignmentReferences(ConsignmentReferenceType.D, "9GB12345678")
   private val page = instanceOf[movement_confirmation_page]
 
   "View" should {
     "render title" in {
-      page(JourneyType.RETROSPECTIVE_ARRIVE, consignmentReferences).getTitle must containMessage("movement.confirmation.title.RETROSPECTIVE_ARRIVE")
+      page(JourneyType.RETROSPECTIVE_ARRIVE).getTitle must containMessage("movement.confirmation.title.RETROSPECTIVE_ARRIVE")
     }
 
     "render page title" in {
-      page(JourneyType.RETROSPECTIVE_ARRIVE, consignmentReferences)
+      page(JourneyType.RETROSPECTIVE_ARRIVE)
         .getElementsByClass("govuk-heading-xl")
         .first() must containMessage("movement.confirmation.title.RETROSPECTIVE_ARRIVE")
     }
 
     "have 'notification timeline' link" in {
-      val inset = page(JourneyType.RETROSPECTIVE_ARRIVE, consignmentReferences).getElementsByClass("govuk-inset-text").first()
+      val inset = page(JourneyType.RETROSPECTIVE_ARRIVE).getElementsByClass("govuk-inset-text").first()
       inset
         .getElementsByClass("govuk-link")
         .first() must haveHref(controllers.routes.ViewSubmissionsController.displayPage())
     }
 
     "have 'find another consignment' link" in {
-      page(JourneyType.RETROSPECTIVE_ARRIVE, consignmentReferences)
+      page(JourneyType.RETROSPECTIVE_ARRIVE)
         .getElementsByClass("govuk-link")
         .get(1) must haveHref(controllers.routes.ChoiceController.displayPage())
     }


### PR DESCRIPTION
This is a feature branch to consolidate merges from all related page-specific branches:

* CEDS-2098-arrive (affects departure and retrospective arrival) - ok
* CEDS-2098-associate - ok
* CEDS-2098-disassociate - ok
* CEDS-2098-shut - ok
* CEDS-2098-clean - TODO

It is an alternative confirmation screen to implement in the internal service as a way of avoiding cases being closed when they shouldn't be.

Currently, NCH operators see the existing confirmation screen at the end of each movement request journey and believe that it means their request has been completed and accepted. As their request has only been submitted to DMS and the acceptance (or rejection) is asynchronous, this could be misleading.