### PR TITLE
CEDS-2102 - store queried ucr and type as preparation for journeys

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -40,8 +40,9 @@ class ChoiceController @Inject()(
 
   def displayPage: Action[AnyContent] = authenticate.async { implicit request =>
     cacheRepository.findByProviderId(request.providerId).map {
-      case Some(cache) => Ok(choicePage(Choice.form().fill(Choice(cache.answers.`type`))))
-      case None        => Ok(choicePage(Choice.form()))
+      case Some(cache) =>
+        cache.answers.map(answers => Ok(choicePage(Choice.form().fill(Choice(answers.`type`))))).getOrElse(Ok(choicePage(Choice.form())))
+      case None => Ok(choicePage(Choice.form()))
     }
   }
 

--- a/app/controllers/actions/JourneyRefiner.scala
+++ b/app/controllers/actions/JourneyRefiner.scala
@@ -35,7 +35,7 @@ class JourneyRefiner @Inject()(cacheRepository: CacheRepository)(implicit val ex
     cacheRepository.findByProviderId(request.operator.providerId).map(_.flatMap(_.answers)).map {
       case Some(answers: Answers) if types.isEmpty || types.contains(answers.`type`) =>
         Right(JourneyRequest(answers, request))
-      case a =>
+      case _ =>
         Left(Results.Redirect(controllers.routes.ChoiceController.displayPage()))
     }
 

--- a/app/controllers/actions/JourneyRefiner.scala
+++ b/app/controllers/actions/JourneyRefiner.scala
@@ -32,10 +32,11 @@ class JourneyRefiner @Inject()(cacheRepository: CacheRepository)(implicit val ex
   override protected def executionContext: ExecutionContext = exc
 
   private def refiner[A](request: AuthenticatedRequest[A], types: JourneyType*): Future[Either[Result, JourneyRequest[A]]] =
-    cacheRepository.findByProviderId(request.operator.providerId).map(_.map(_.answers)).map {
+    cacheRepository.findByProviderId(request.operator.providerId).map(_.flatMap(_.answers)).map {
       case Some(answers: Answers) if types.isEmpty || types.contains(answers.`type`) =>
         Right(JourneyRequest(answers, request))
-      case _ =>
+      case a =>
+        print(s"foud this " + a)
         Left(Results.Redirect(controllers.routes.ChoiceController.displayPage()))
     }
 

--- a/app/controllers/actions/JourneyRefiner.scala
+++ b/app/controllers/actions/JourneyRefiner.scala
@@ -36,7 +36,6 @@ class JourneyRefiner @Inject()(cacheRepository: CacheRepository)(implicit val ex
       case Some(answers: Answers) if types.isEmpty || types.contains(answers.`type`) =>
         Right(JourneyRequest(answers, request))
       case a =>
-        print(s"foud this " + a)
         Left(Results.Redirect(controllers.routes.ChoiceController.displayPage()))
     }
 

--- a/app/models/cache/Cache.scala
+++ b/app/models/cache/Cache.scala
@@ -16,10 +16,14 @@
 
 package models.cache
 
+import models.UcrBlock
 import play.api.libs.json.{Json, OFormat}
 
-case class Cache(providerId: String, answers: Answers)
+case class Cache(providerId: String, answers: Option[Answers], queryUcr: Option[UcrBlock])
 
 object Cache {
   implicit val format: OFormat[Cache] = Json.format[Cache]
+
+  def apply(providerId: String, answers: Answers): Cache = new Cache(providerId, Some(answers), None)
+  def apply(providerId: String, queryUcr: UcrBlock): Cache = new Cache(providerId, None, Some(queryUcr))
 }

--- a/test/it/IntegrationSpec.scala
+++ b/test/it/IntegrationSpec.scala
@@ -69,7 +69,7 @@ abstract class IntegrationSpec
     route(app, request).get
   }
 
-  protected def theCacheFor(pid: String): Option[Answers] = await(cacheRepository.find(Json.obj("providerId" -> pid)).one[Cache]).map(_.answers)
+  protected def theCacheFor(pid: String): Option[Answers] = await(cacheRepository.find(Json.obj("providerId" -> pid)).one[Cache]).flatMap(_.answers)
 
   protected def givenCacheFor(pid: String, answers: Answers): Unit = await(cacheRepository.insert(Cache.format.writes(Cache(pid, answers))))
 

--- a/test/unit/controllers/consolidations/DisassociateUCRControllerSpec.scala
+++ b/test/unit/controllers/consolidations/DisassociateUCRControllerSpec.scala
@@ -71,7 +71,7 @@ class DisassociateUCRControllerSpec extends ControllerLayerSpec with MockCache {
 
       status(result) mustBe Status.SEE_OTHER
       redirectLocation(result) mustBe Some(routes.DisassociateUCRSummaryController.display().url)
-      theCacheUpserted.answers mustBe DisassociateUcrAnswers(ucr = Some(disassociation))
+      theCacheUpserted.answers mustBe Some(DisassociateUcrAnswers(ucr = Some(disassociation)))
     }
 
     "return 400 when invalid" in {

--- a/test/unit/controllers/movements/ConsignmentReferencesControllerSpec.scala
+++ b/test/unit/controllers/movements/ConsignmentReferencesControllerSpec.scala
@@ -110,7 +110,7 @@ class ConsignmentReferencesControllerSpec extends ControllerLayerSpec with MockC
 
         await(controller().saveConsignmentReferences()(postRequest(correctForm)))
 
-        theCacheUpserted.answers mustBe an[ArrivalAnswers]
+        theCacheUpserted.answers mustBe an[Option[ArrivalAnswers]]
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -136,7 +136,7 @@ class ConsignmentReferencesControllerSpec extends ControllerLayerSpec with MockC
 
         await(controller(RetrospectiveArrivalAnswers()).saveConsignmentReferences()(postRequest(correctForm)))
 
-        theCacheUpserted.answers mustBe an[RetrospectiveArrivalAnswers]
+        theCacheUpserted.answers mustBe an[Option[RetrospectiveArrivalAnswers]]
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -162,7 +162,7 @@ class ConsignmentReferencesControllerSpec extends ControllerLayerSpec with MockC
 
         await(controller(DepartureAnswers()).saveConsignmentReferences()(postRequest(correctForm)))
 
-        theCacheUpserted.answers mustBe an[DepartureAnswers]
+        theCacheUpserted.answers mustBe an[Option[DepartureAnswers]]
       }
 
       "return 303 (SEE_OTHER)" in {

--- a/test/unit/controllers/movements/GoodsDepartedControllerSpec.scala
+++ b/test/unit/controllers/movements/GoodsDepartedControllerSpec.scala
@@ -111,7 +111,7 @@ class GoodsDepartedControllerSpec extends ControllerLayerSpec with MockCache {
 
         await(controller().saveGoodsDeparted()(postRequest(correctForm)))
 
-        cachePassedToRepository.answers mustBe DepartureAnswers(goodsDeparted = Some(GoodsDeparted(BackIntoTheUk)))
+        cachePassedToRepository.answers mustBe Some(DepartureAnswers(goodsDeparted = Some(GoodsDeparted(BackIntoTheUk))))
       }
 
       "return 303 (SEE_OTHER) and redirect to Transport page" in {

--- a/test/unit/controllers/movements/LocationControllerSpec.scala
+++ b/test/unit/controllers/movements/LocationControllerSpec.scala
@@ -126,7 +126,7 @@ class LocationControllerSpec extends ControllerLayerSpec with MockCache {
 
         await(controller(ArrivalAnswers()).saveLocation()(postRequest(correctForm)))
 
-        theCacheUpserted.answers mustBe an[ArrivalAnswers]
+        theCacheUpserted.answers mustBe an[Option[ArrivalAnswers]]
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -152,7 +152,7 @@ class LocationControllerSpec extends ControllerLayerSpec with MockCache {
 
         await(controller(RetrospectiveArrivalAnswers()).saveLocation()(postRequest(correctForm)))
 
-        theCacheUpserted.answers mustBe an[RetrospectiveArrivalAnswers]
+        theCacheUpserted.answers mustBe an[Option[RetrospectiveArrivalAnswers]]
       }
 
       "return 303 (SEE_OTHER)" in {
@@ -178,7 +178,7 @@ class LocationControllerSpec extends ControllerLayerSpec with MockCache {
 
         await(controller(DepartureAnswers()).saveLocation()(postRequest(correctForm)))
 
-        theCacheUpserted.answers mustBe an[DepartureAnswers]
+        theCacheUpserted.answers mustBe an[Option[DepartureAnswers]]
       }
 
       "return 303 (SEE_OTHER)" in {


### PR DESCRIPTION
This PR saves the queried ucr and type as part of the viewing of ILE Query Results to the users cache.  
Nothing is done with that saved data at present, but it will be used in future to integrate the queried ucr into the various journeys (i.e. to pre-fill questions or even skip pages)