### PR TITLE
CEDS-2093 - add back button to choice page 

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -41,8 +41,10 @@ class ChoiceController @Inject()(
   def displayPage: Action[AnyContent] = authenticate.async { implicit request =>
     cacheRepository.findByProviderId(request.providerId).map {
       case Some(cache) =>
-        cache.answers.map(answers => Ok(choicePage(Choice.form().fill(Choice(answers.`type`))))).getOrElse(Ok(choicePage(Choice.form())))
-      case None => Ok(choicePage(Choice.form()))
+        cache.answers
+          .map(answers => Ok(choicePage(Choice.form().fill(Choice(answers.`type`)), cache.queryUcr)))
+          .getOrElse(Ok(choicePage(Choice.form(), cache.queryUcr)))
+      case None => Ok(choicePage(Choice.form(), None))
     }
   }
 

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -23,12 +23,14 @@
 
 @this(main_template: main_template)
 
-@(form: Form[Choice])(implicit request: Request[_], messages: Messages)
+@(form: Form[Choice], queryUcr: Option[UcrBlock] = None)(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Title("movement.choice.title")) {
 
     @helper.form(routes.ChoiceController.submit(), 'autoComplete -> "off") {
         @helper.CSRF.formField
+
+        @queryUcr.map(block => components.back_link(controllers.ileQuery.routes.IleQueryController.submitQuery(block.ucr)))
 
         @components.error_summary(form.errors)
 

--- a/test/unit/views/ChoicePageViewSpec.scala
+++ b/test/unit/views/ChoicePageViewSpec.scala
@@ -17,6 +17,7 @@
 package views
 
 import forms.Choice
+import models.UcrBlock
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.FakeRequest
 import views.html.choice_page
@@ -53,6 +54,23 @@ class ChoicePageViewSpec extends ViewSpec {
 
       "some errors" in {
         page(Choice.form().withError("error", "error.required")).getErrorSummary mustBe defined
+      }
+    }
+
+    "render back link" when {
+      "form contains ucr block" in {
+        val backButton = page(Choice.form(), Some(UcrBlock("ucr", "D"))).getBackButton
+
+        backButton mustBe defined
+        backButton.get must haveHref(controllers.ileQuery.routes.IleQueryController.submitQuery("ucr"))
+      }
+    }
+
+    "not render back link" when {
+      "form does not contain ucr block" in {
+        val backButton = page(Choice.form(), None).getBackButton
+
+        backButton mustNot be(defined)
       }
     }
   }


### PR DESCRIPTION
This should link back to the consignment details for the previous ILE Query search (re-submitting the search as part of the process).

The link is only rendered if we have a UcrBlock present in the users cache (which in turn only gets added to the cache upon the successful completion of an ILE search).