### PR TITLE
Close Mongobee runner after execution

### DIFF
--- a/app/mongobee/MongobeeConfig.scala
+++ b/app/mongobee/MongobeeConfig.scala
@@ -27,4 +27,5 @@ case class MongobeeConfig(mongoURI: String) {
   runner.setChangeLogsScanPackage("mongobee.changesets")
 
   runner.execute()
+  runner.close()
 }


### PR DESCRIPTION
This solves the problem that Mongobee was not closing opened DB
connections after execution. This was causing Mongo to crash during unit
tests execution (over 100 new connections were created).