### PR TITLE
CEDS-2164 - add TTL of 60 mins to cache

### DIFF
--- a/app/mongobee/changesets/CacheChangelog.java
+++ b/app/mongobee/changesets/CacheChangelog.java
@@ -18,7 +18,16 @@ package mongobee.changesets;
 
 import com.github.mongobee.changeset.ChangeLog;
 import com.github.mongobee.changeset.ChangeSet;
+import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import org.bson.Document;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @ChangeLog
 public class CacheChangelog {
@@ -26,5 +35,16 @@ public class CacheChangelog {
 
     @ChangeSet(order = "001", id = "Internal Movements DB Baseline", author = "Paulo Monteiro")
     public void dbBaseline(DB db) {
+    }
+
+    @ChangeSet(order = "002", id = "Add 'updated' field to cache and ttl of 60 mins", author = "Steve Sugden")
+    public void addCacheUpdateField(MongoDatabase db) {
+
+        Document query = new Document();
+        Document update = new Document("$set", new Document("updated", Date.from(Instant.now())));
+        db.getCollection(collection).updateMany(new BasicDBObject(query), new BasicDBObject(update));
+
+        IndexOptions options = new IndexOptions().expireAfter(60L, TimeUnit.MINUTES).name("ttl");
+        db.getCollection(collection).createIndex(Indexes.ascending("updated"), options);
     }
 }

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -183,7 +183,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(movements.routes.ConsignmentReferencesController.displayPage().url)
-        theCacheUpserted mustBe Cache(providerId, ArrivalAnswers(Answers.fakeEORI))
+        theCacheUpserted.answers mustBe Some(ArrivalAnswers(Answers.fakeEORI))
       }
 
       "user chooses departure" in {
@@ -192,7 +192,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(movements.routes.ConsignmentReferencesController.displayPage().url)
-        theCacheUpserted mustBe Cache(providerId, DepartureAnswers(Answers.fakeEORI))
+        theCacheUpserted.answers mustBe Some(DepartureAnswers(Answers.fakeEORI))
       }
 
       "user chooses associate UCR" in {
@@ -201,7 +201,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(consolidationRoutes.MucrOptionsController.displayPage().url)
-        theCacheUpserted mustBe Cache(providerId, AssociateUcrAnswers())
+        theCacheUpserted.answers mustBe Some(AssociateUcrAnswers())
       }
 
       "user chooses disassociate UCR" in {
@@ -210,7 +210,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(consolidationRoutes.DisassociateUCRController.display().url)
-        theCacheUpserted mustBe Cache(providerId, DisassociateUcrAnswers())
+        theCacheUpserted.answers mustBe Some(DisassociateUcrAnswers())
       }
 
       "user chooses shut MUCR" in {
@@ -219,7 +219,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(consolidationRoutes.ShutMucrController.displayPage().url)
-        theCacheUpserted mustBe Cache(providerId, ShutMucrAnswers())
+        theCacheUpserted.answers mustBe Some(ShutMucrAnswers())
       }
 
       "user chooses retrospective arrival" in {
@@ -228,7 +228,7 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(movements.routes.ConsignmentReferencesController.displayPage().url)
-        theCacheUpserted mustBe Cache(providerId, RetrospectiveArrivalAnswers())
+        theCacheUpserted.answers mustBe Some(RetrospectiveArrivalAnswers())
       }
 
       "user chooses view submissions" in {
@@ -269,11 +269,10 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit(postWithChoice(Arrival))
 
         status(result) mustBe SEE_OTHER
-        theCacheUpserted mustBe Cache(
-          providerId,
-          Some(ArrivalAnswers(Answers.fakeEORI, consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "mucr")))),
-          Some(queryResult)
+        theCacheUpserted.answers mustBe Some(
+          ArrivalAnswers(Answers.fakeEORI, consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "mucr")))
         )
+        theCacheUpserted.queryUcr mustBe Some(queryResult)
       }
 
       "user chooses departure following ILE query results" in {
@@ -283,11 +282,10 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit(postWithChoice(Departure))
 
         status(result) mustBe SEE_OTHER
-        theCacheUpserted mustBe Cache(
-          providerId,
-          Some(DepartureAnswers(Answers.fakeEORI, consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "mucr")))),
-          Some(queryResult)
+        theCacheUpserted.answers mustBe Some(
+          DepartureAnswers(Answers.fakeEORI, consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "mucr")))
         )
+        theCacheUpserted.queryUcr mustBe Some(queryResult)
       }
 
       "user chooses associate UCR following ILE query results" in {
@@ -297,11 +295,8 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit(postWithChoice(AssociateUCR))
 
         status(result) mustBe SEE_OTHER
-        theCacheUpserted mustBe Cache(
-          providerId,
-          Some(AssociateUcrAnswers(Answers.fakeEORI, associateUcr = Some(AssociateUcr(AssociateKind.Mucr, "mucr")))),
-          Some(queryResult)
-        )
+        theCacheUpserted.answers mustBe Some(AssociateUcrAnswers(Answers.fakeEORI, associateUcr = Some(AssociateUcr(AssociateKind.Mucr, "mucr"))))
+        theCacheUpserted.queryUcr mustBe Some(queryResult)
       }
 
       "user chooses disassociate UCR following ILE query results" in {
@@ -311,11 +306,10 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit(postWithChoice(DisassociateUCR))
 
         status(result) mustBe SEE_OTHER
-        theCacheUpserted mustBe Cache(
-          providerId,
-          Some(DisassociateUcrAnswers(Answers.fakeEORI, ucr = Some(DisassociateUcr(DisassociateKind.Mucr, None, Some("mucr"))))),
-          Some(queryResult)
+        theCacheUpserted.answers mustBe Some(
+          DisassociateUcrAnswers(Answers.fakeEORI, ucr = Some(DisassociateUcr(DisassociateKind.Mucr, None, Some("mucr"))))
         )
+        theCacheUpserted.queryUcr mustBe Some(queryResult)
       }
 
       "user chooses shut MUCR following ILE query results" in {
@@ -325,7 +319,8 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit(postWithChoice(ShutMUCR))
 
         status(result) mustBe SEE_OTHER
-        theCacheUpserted mustBe Cache(providerId, Some(ShutMucrAnswers(Answers.fakeEORI, shutMucr = Some(ShutMucr("mucr")))), Some(queryResult))
+        theCacheUpserted.answers mustBe Some(ShutMucrAnswers(Answers.fakeEORI, shutMucr = Some(ShutMucr("mucr"))))
+        theCacheUpserted.queryUcr mustBe Some(queryResult)
       }
 
       "user chooses retrospective arrival following ILE query results" in {
@@ -335,13 +330,10 @@ class ChoiceControllerSpec extends ControllerLayerSpec with MockCache {
         val result = controller().submit(postWithChoice(RetrospectiveArrival))
 
         status(result) mustBe SEE_OTHER
-        theCacheUpserted mustBe Cache(
-          providerId,
-          Some(
-            RetrospectiveArrivalAnswers(Answers.fakeEORI, consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "mucr")))
-          ),
-          Some(queryResult)
+        theCacheUpserted.answers mustBe Some(
+          RetrospectiveArrivalAnswers(Answers.fakeEORI, consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "mucr")))
         )
+        theCacheUpserted.queryUcr mustBe Some(queryResult)
       }
 
     }


### PR DESCRIPTION
Same change as external movements frontend service - 
- added new "updated" field to cache model with default of "now"
- updated the db (using Mongobee) to add field to existing cache objects and add ttl index to cache collection