### PR TITLE
BAU - move creation of IleQueries ttl index to mongobee changelog

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -54,8 +54,6 @@ class AppConfig @Inject()(
   lazy val customsDeclarationsGoodsTakenOutOfEuUrl: String = loadConfig("urls.customsDeclarationsGoodsTakenOutOfEu")
   lazy val serviceAvailabilityUrl: String = loadConfig("urls.serviceAvailability")
 
-  lazy val ileQueryTTL: FiniteDuration = servicesConfig.getDuration("ileQuery.ttl").asInstanceOf[FiniteDuration]
-
   private def featureSwitch(key: String): Boolean =
     runModeConfiguration.getOptional[Boolean](s"featureSwitches.$key").getOrElse(false)
 

--- a/app/mongobee/changesets/IleQueriesChangelog.java
+++ b/app/mongobee/changesets/IleQueriesChangelog.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongobee.changesets;
+
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeSet;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import com.mongodb.client.model.Indexes;
+import org.bson.Document;
+
+import java.util.concurrent.TimeUnit;
+
+@ChangeLog
+public class IleQueriesChangelog {
+    private String collection = "ileQueries";
+
+    @ChangeSet(order = "001", id = "Add ttl of 1 min", author = "Steve Sugden")
+    public void addIleQueryTTL(MongoDatabase db) {
+
+        /*
+        Note:  Have to check for existence of index as it was previously created by the IleQueryRepository class
+         */
+        dropIndexIfExists("ttl", db.getCollection(collection));
+
+        IndexOptions options = new IndexOptions().expireAfter(1L, TimeUnit.MINUTES).name("ttl");
+        db.getCollection(collection).createIndex(Indexes.ascending("createdAt"), options);
+    }
+
+    private void dropIndexIfExists(String key, MongoCollection<Document> collection) {
+        for (Document index : collection.listIndexes()) {
+            if (index.containsKey(key)) {
+                collection.dropIndex(key);
+            }
+        }
+    }
+}

--- a/app/repositories/IleQueryRepository.scala
+++ b/app/repositories/IleQueryRepository.scala
@@ -21,8 +21,7 @@ import javax.inject.Inject
 import models.cache.IleQuery
 import play.api.libs.json.JsString
 import play.modules.reactivemongo.ReactiveMongoComponent
-import reactivemongo.api.indexes.{Index, IndexType}
-import reactivemongo.bson.{BSONDocument, BSONObjectID}
+import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.objectIdFormats
 
@@ -30,14 +29,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class IleQueryRepository @Inject()(mc: ReactiveMongoComponent, appConfig: AppConfig)(implicit ec: ExecutionContext)
     extends ReactiveRepository[IleQuery, BSONObjectID]("ileQueries", mc.mongoConnector.db, IleQuery.format, objectIdFormats) {
-
-  override def indexes: Seq[Index] = super.indexes ++ Seq(
-    Index(
-      key = Seq("createdAt" -> IndexType.Ascending),
-      name = Some("ttl"),
-      options = BSONDocument("expireAfterSeconds" -> appConfig.ileQueryTTL.toSeconds)
-    )
-  )
 
   def findBySessionIdAndUcr(sessionId: String, ucr: String): Future[Option[IleQuery]] =
     find("sessionId" -> sessionId, "ucr" -> ucr).map(_.headOption)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -92,10 +92,6 @@ microservice {
   }
 }
 
-ileQuery {
-  ttl = "1min"
-}
-
 mongodb {
   uri = "mongodb://localhost:27017/customs-exports-internal"
 }


### PR DESCRIPTION
This change is not strictly necessary but it keeps the creation of indexes consistent (i.e. in the mongobee changelog scripts).

In addition, it solves the problem that the ttl timeout value was not changeable via the config (if the db already had the index).