### PR TITLE
CEDS-2100 - Make searching for a consignment the first step in the service

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -51,6 +51,4 @@ class AppConfig @Inject()(
 
   private def featureSwitch(key: String): Boolean =
     runModeConfiguration.getOptional[Boolean](s"featureSwitches.$key").getOrElse(false)
-
-  lazy val hasIleQueryFeature: Boolean = featureSwitch("ileQueryEnabled")
 }

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -45,7 +45,7 @@ class ChoiceController @Inject()(
         cache.answers
           .map(answers => Ok(choicePage(Choice.form().fill(Choice(answers.`type`)), cache.queryUcr)))
           .getOrElse(Ok(choicePage(Choice.form(), cache.queryUcr)))
-      case None => Ok(choicePage(Choice.form(), None))
+      case None => Redirect(controllers.ileQuery.routes.IleQueryController.displayQueryForm())
     }
   }
 

--- a/app/views/components/confirmation_link.scala.html
+++ b/app/views/components/confirmation_link.scala.html
@@ -23,9 +23,5 @@
 @()(implicit messages: Messages)
 
 <p class="govuk-body">
-    @if(appConfig.hasIleQueryFeature) {
-        @link(message = messages("movement.confirmation.redirect.query.link"), href = ileQuery.routes.IleQueryController.displayQueryForm())
-    } else {
-        @link(message = messages("movement.confirmation.redirect.choice.link"), href = routes.ChoiceController.displayPage())
-    }
+    @link(message = messages("movement.confirmation.redirect.query.link"), href = ileQuery.routes.IleQueryController.displayQueryForm())
 </p>

--- a/app/views/components/gds/exportsInputText.scala.html
+++ b/app/views/components/gds/exportsInputText.scala.html
@@ -18,10 +18,10 @@
 
 @this(govukInput: GovukInput)
 
-@(field: Field, labelKey: String, hintKey: Option[String] = None, isPageHeading: Boolean = false)(implicit messages: Messages)
+@(field: Field, labelKey: String, hintKey: Option[String] = None, isPageHeading: Boolean = false, headingClasses: String = "govuk-label--l")(implicit messages: Messages)
 
 @buildLabel = @{ if(isPageHeading) {
-    Label(content = Text(messages(labelKey)), isPageHeading = true,  classes = "govuk-label--l")
+    Label(content = Text(messages(labelKey)), isPageHeading = true,  classes = headingClasses)
   } else {
     Label(content = Text(messages(labelKey)))
   }

--- a/app/views/ile_query.scala.html
+++ b/app/views/ile_query.scala.html
@@ -15,26 +15,41 @@
  *@
 
 @import views.Title
+@import views.html.components.gds.link
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import components.gds.{errorSummary, gds_main_template, pageTitle}
+@import views.html.components.gds.exportsInputText
 
-@this(main_template: views.html.templates.main_template)
+@this(
+        govukLayout: gds_main_template,
+        govukButton: GovukButton,
+        exportsInputText: exportsInputText,
+        errorSummary: errorSummary,
+        pageTitle: pageTitle,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(form: Form[String])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Title("ileQuery.title")) {
+@govukLayout(
+    title = Title("ileQuery.title")) {
 
-  @helper.form(controllers.ileQuery.routes.IleQueryController.submitQueryForm, 'autoComplete -> "off") {
+    @formHelper(action = controllers.ileQuery.routes.IleQueryController.submitQueryForm(), 'autoComplete -> "off") {
 
-    @helper.CSRF.formField
+        @errorSummary(form.errors)
 
-    @components.error_summary(form.errors)
+        @exportsInputText(
+          field = form("ucr"),
+            labelKey = "ileQuery.title",
+            isPageHeading = true,
+            headingClasses = "govuk-label--xl"
+        )
 
-    @components.page_title(Some(messages("ileQuery.title")))
+        @govukButton(Button(content = Text(messages("site.continue"))))
 
-    @components.input_text(
-      field = form("ucr"),
-      label = ""
-    )
+        <ul class="govuk-list">
+            <li>@link(message = messages("ileQuery.link.requests"), href = routes.ViewSubmissionsController.displayPage())</li>
+        </ul>
 
-    @components.submit_button(messages("site.continue"))
-  }
+    }
 }

--- a/app/views/view_submissions.scala.html
+++ b/app/views/view_submissions.scala.html
@@ -27,7 +27,7 @@
 
 @main_template(title = Title("submissions.title"), fullWidth = true) {
 
-  @components.back_link(routes.ChoiceController.displayPage())
+  @components.back_link(controllers.ileQuery.routes.IleQueryController.submitQueryForm())
 
   @components.page_title(Some(messages("submissions.title")))
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,6 +1,12 @@
 # microservice specific routes
 GET         /assets/*file                          controllers.Assets.versioned(path="/public", file: Asset)
 
+# ILE Query - entry point
+GET         /consignment-query                     controllers.ileQuery.IleQueryController.displayQueryForm()
+POST        /consignment-query                     controllers.ileQuery.IleQueryController.submitQueryForm()
+
+GET         /consignment-query/:ucr                controllers.ileQuery.IleQueryController.submitQuery(ucr: String)
+
 # Declaration choice page
 GET         /choice                                controllers.ChoiceController.displayPage()
 GET         /choice/:journey                       controllers.ChoiceController.startSpecificJourney(journey: forms.Choice)
@@ -75,3 +81,4 @@ GET         /submissions                           controllers.ViewSubmissionsCo
 
 # Notifications page
 GET         /notifications/:conversationId         controllers.ViewNotificationsController.listOfNotifications(conversationId)
+

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -132,5 +132,5 @@ urls {
 }
 
 featureSwitches {
-  ileQueryEnabled = true
+
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -326,6 +326,10 @@ ileQuery.title = Find a consignment
 ileQuery.ucr.empty = Enter a Unique Consignment Reference
 ileQuery.ucr.incorrect = Unique Consignment Reference is incorrect
 
+ileQuery.link.emptyMucr = Create an empty Master Consignment Reference (MUCR)
+ileQuery.link.requests = View previous requests
+
+
 ileQuery.loading.title = Looking for consignment
 ileQuery.loading.hint = This should only take a few seconds, do not refresh the page
 

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -12,8 +12,3 @@
 # Add all the application routes to the prod.routes file
 ->         /                          prod.Routes
 
-# ILE Query
-GET         /customs-exports-internal/consignment-query                     controllers.ileQuery.IleQueryController.displayQueryForm()
-POST        /customs-exports-internal/consignment-query                     controllers.ileQuery.IleQueryController.submitQueryForm()
-
-GET         /customs-exports-internal/consignment-query/:ucr                controllers.ileQuery.IleQueryController.submitQuery(ucr: String)

--- a/test/it/ArrivalSpec.scala
+++ b/test/it/ArrivalSpec.scala
@@ -61,7 +61,7 @@ class ArrivalSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementDetailsController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           ArrivalAnswers(consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")))
         )
       }
@@ -102,7 +102,7 @@ class ArrivalSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.LocationController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           ArrivalAnswers(
             consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")),
             arrivalDetails = Some(ArrivalDetails(Date(date), Time(time)))
@@ -151,7 +151,7 @@ class ArrivalSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementSummaryController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           ArrivalAnswers(
             consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")),
             arrivalDetails = Some(ArrivalDetails(Date(date), Time(time))),
@@ -204,7 +204,7 @@ class ArrivalSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementConfirmationController.display().url)
-        theCacheFor("pid") mustBe None
+        theAnswersFor("pid") mustBe None
         verify(
           postRequestedForMovement()
             .withRequestBody(equalToJson(s"""{

--- a/test/it/AssociateUcrSpec.scala
+++ b/test/it/AssociateUcrSpec.scala
@@ -43,7 +43,7 @@ class AssociateUcrSpec extends IntegrationSpec {
 
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUCRController.displayPage().url)
-        theCacheFor("pid") mustBe Some(AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = Create, newMucr = "GB/123-12345"))))
+        theAnswersFor("pid") mustBe Some(AssociateUcrAnswers(mucrOptions = Some(MucrOptions(createOrAdd = Create, newMucr = "GB/123-12345"))))
       }
     }
   }
@@ -69,7 +69,7 @@ class AssociateUcrSpec extends IntegrationSpec {
 
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUCRSummaryController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           AssociateUcrAnswers(
             mucrOptions = Some(MucrOptions(createOrAdd = Create, newMucr = "GB/123-12345")),
             associateUcr = Some(AssociateUcr(AssociateKind.Mucr, "GB/321-54321"))
@@ -113,7 +113,7 @@ class AssociateUcrSpec extends IntegrationSpec {
 
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.AssociateUCRConfirmationController.display().url)
-        theCacheFor("pid") mustBe None
+        theAnswersFor("pid") mustBe None
         verify(
           postRequestedForConsolidation()
             .withRequestBody(

--- a/test/it/ChoiceSpec.scala
+++ b/test/it/ChoiceSpec.scala
@@ -14,7 +14,12 @@
  * limitations under the License.
  */
 
-import forms.Choice
+import java.time.{LocalDate, LocalTime}
+import java.time.temporal.ChronoUnit
+
+import forms.common.{Date, Time}
+import forms.{ArrivalDetails, Choice, ConsignmentReferenceType, ConsignmentReferences}
+import models.UcrBlock
 import models.cache._
 import play.api.test.Helpers._
 
@@ -29,8 +34,17 @@ class ChoiceSpec extends IntegrationSpec {
       status(response) mustBe FORBIDDEN
     }
 
-    "return 200" in {
+    "return 303 if there is no cache" in {
       givenAuthSuccess()
+
+      val response = get(controllers.routes.ChoiceController.displayPage())
+
+      status(response) mustBe SEE_OTHER
+    }
+
+    "return 200 if there is an UCR in the cache" in {
+      givenAuthSuccess("pid")
+      givenCacheFor(pid = "pid", queryUcr = UcrBlock("GB/123-12345", "M"))
 
       val response = get(controllers.routes.ChoiceController.displayPage())
 
@@ -54,7 +68,7 @@ class ChoiceSpec extends IntegrationSpec {
         val response = post(controllers.routes.ChoiceController.submit(), "choice" -> Choice.Departure.value)
 
         status(response) mustBe SEE_OTHER
-        theCacheFor("pid") mustBe Some(DepartureAnswers())
+        theAnswersFor("pid") mustBe Some(DepartureAnswers())
       }
 
       "Arrival" in {
@@ -63,7 +77,7 @@ class ChoiceSpec extends IntegrationSpec {
         val response = post(controllers.routes.ChoiceController.submit(), "choice" -> Choice.Arrival.value)
 
         status(response) mustBe SEE_OTHER
-        theCacheFor("pid") mustBe Some(ArrivalAnswers())
+        theAnswersFor("pid") mustBe Some(ArrivalAnswers())
       }
 
       "Associate UCR" in {
@@ -72,7 +86,7 @@ class ChoiceSpec extends IntegrationSpec {
         val response = post(controllers.routes.ChoiceController.submit(), "choice" -> Choice.AssociateUCR.value)
 
         status(response) mustBe SEE_OTHER
-        theCacheFor("pid") mustBe Some(AssociateUcrAnswers())
+        theAnswersFor("pid") mustBe Some(AssociateUcrAnswers())
       }
 
       "Dissociate UCR" in {
@@ -81,7 +95,7 @@ class ChoiceSpec extends IntegrationSpec {
         val response = post(controllers.routes.ChoiceController.submit(), "choice" -> Choice.DisassociateUCR.value)
 
         status(response) mustBe SEE_OTHER
-        theCacheFor("pid") mustBe Some(DisassociateUcrAnswers())
+        theAnswersFor("pid") mustBe Some(DisassociateUcrAnswers())
       }
 
       "Shut MUCR" in {
@@ -90,7 +104,7 @@ class ChoiceSpec extends IntegrationSpec {
         val response = post(controllers.routes.ChoiceController.submit(), "choice" -> Choice.ShutMUCR.value)
 
         status(response) mustBe SEE_OTHER
-        theCacheFor("pid") mustBe Some(ShutMucrAnswers())
+        theAnswersFor("pid") mustBe Some(ShutMucrAnswers())
       }
     }
   }

--- a/test/it/DepartureSpec.scala
+++ b/test/it/DepartureSpec.scala
@@ -62,7 +62,7 @@ class DepartureSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementDetailsController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           DepartureAnswers(consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")))
         )
       }
@@ -103,7 +103,7 @@ class DepartureSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.LocationController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           DepartureAnswers(
             consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")),
             departureDetails = Some(DepartureDetails(Date(date), Time(time)))
@@ -152,7 +152,7 @@ class DepartureSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.GoodsDepartedController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           DepartureAnswers(
             consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")),
             departureDetails = Some(DepartureDetails(Date(date), Time(time))),
@@ -204,7 +204,7 @@ class DepartureSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.TransportController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           DepartureAnswers(
             consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")),
             departureDetails = Some(DepartureDetails(Date(date), Time(time))),
@@ -264,7 +264,7 @@ class DepartureSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementSummaryController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           DepartureAnswers(
             consignmentReferences = Some(ConsignmentReferences(ConsignmentReferenceType.M, "GB/123-12345")),
             departureDetails = Some(DepartureDetails(Date(date), Time(time))),
@@ -323,7 +323,7 @@ class DepartureSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementConfirmationController.display().url)
-        theCacheFor("pid") mustBe None
+        theAnswersFor("pid") mustBe None
         verify(
           postRequestedForMovement()
             .withRequestBody(equalToJson(s"""{

--- a/test/it/DissociateUcrSpec.scala
+++ b/test/it/DissociateUcrSpec.scala
@@ -48,7 +48,7 @@ class DissociateUcrSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.DisassociateUCRSummaryController.display().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           DisassociateUcrAnswers(ucr = Some(DisassociateUcr(kind = DisassociateKind.Mucr, mucr = Some("GB/321-54321"), ducr = None)))
         )
       }
@@ -89,7 +89,7 @@ class DissociateUcrSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.DisassociateUCRConfirmationController.display().url)
-        theCacheFor("pid") mustBe None
+        theAnswersFor("pid") mustBe None
         verify(
           postRequestedForConsolidation()
             .withRequestBody(

--- a/test/it/IntegrationSpec.scala
+++ b/test/it/IntegrationSpec.scala
@@ -17,6 +17,7 @@
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import connectors.{AuditWiremockTestServer, AuthWiremockTestServer, MovementsBackendWiremockTestServer}
+import models.UcrBlock
 import models.cache.{Answers, Cache}
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
@@ -69,9 +70,12 @@ abstract class IntegrationSpec
     route(app, request).get
   }
 
-  protected def theCacheFor(pid: String): Option[Answers] = await(cacheRepository.find(Json.obj("providerId" -> pid)).one[Cache]).flatMap(_.answers)
+  protected def theCacheFor(pid: String): Option[Cache] = await(cacheRepository.find(Json.obj("providerId" -> pid)).one[Cache])
+  protected def theAnswersFor(pid: String): Option[Answers] = await(cacheRepository.find(Json.obj("providerId" -> pid)).one[Cache]).flatMap(_.answers)
 
   protected def givenCacheFor(pid: String, answers: Answers): Unit = await(cacheRepository.insert(Cache.format.writes(Cache(pid, answers))))
+
+  protected def givenCacheFor(pid: String, queryUcr: UcrBlock): Unit = await(cacheRepository.insert(Cache.format.writes(Cache(pid, queryUcr))))
 
   protected def verifyEventually(requestPatternBuilder: RequestPatternBuilder): Unit = eventually(WireMock.verify(requestPatternBuilder))
 

--- a/test/it/RetrospectiveArrivalSpec.scala
+++ b/test/it/RetrospectiveArrivalSpec.scala
@@ -59,7 +59,7 @@ class RetrospectiveArrivalSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.LocationController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           RetrospectiveArrivalAnswers(
             consignmentReferences = Some(ConsignmentReferences(reference = ConsignmentReferenceType.M, referenceValue = "GB/123-12345"))
           )
@@ -105,7 +105,7 @@ class RetrospectiveArrivalSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementSummaryController.displayPage().url)
-        theCacheFor("pid") mustBe Some(
+        theAnswersFor("pid") mustBe Some(
           RetrospectiveArrivalAnswers(
             consignmentReferences = Some(ConsignmentReferences(reference = ConsignmentReferenceType.M, referenceValue = "GB/123-12345")),
             location = Some(Location("GBAUEMAEMAEMA"))
@@ -155,7 +155,7 @@ class RetrospectiveArrivalSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.movements.routes.MovementConfirmationController.display().url)
-        theCacheFor("pid") mustBe None
+        theAnswersFor("pid") mustBe None
         verify(
           postRequestedForMovement()
             .withRequestBody(equalToJson(s"""{

--- a/test/it/ShutMucrSpec.scala
+++ b/test/it/ShutMucrSpec.scala
@@ -48,7 +48,7 @@ class ShutMucrSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.ShutMucrSummaryController.displayPage().url)
-        theCacheFor("pid") mustBe Some(ShutMucrAnswers(shutMucr = Some(ShutMucr("GB/123-12345"))))
+        theAnswersFor("pid") mustBe Some(ShutMucrAnswers(shutMucr = Some(ShutMucr("GB/123-12345"))))
       }
     }
   }
@@ -81,7 +81,7 @@ class ShutMucrSpec extends IntegrationSpec {
         // Then
         status(response) mustBe SEE_OTHER
         redirectLocation(response) mustBe Some(controllers.consolidations.routes.ShutMUCRConfirmationController.display().url)
-        theCacheFor("pid") mustBe None
+        theAnswersFor("pid") mustBe None
         verify(
           postRequestedForConsolidation()
             .withRequestBody(equalToJson("""{"providerId":"pid","eori":"GB1234567890","mucr":"GB/123-12345","consolidationType":"ShutMucr"}"""))

--- a/test/unit/views/components/ConfirmationLinkViewSpec.scala
+++ b/test/unit/views/components/ConfirmationLinkViewSpec.scala
@@ -17,7 +17,6 @@
 package views.components
 
 import config.AppConfig
-import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.FakeRequest
@@ -34,42 +33,13 @@ class ConfirmationLinkViewSpec extends ViewSpec with ViewMatchers with MockitoSu
 
   "Confirmation link component" should {
 
-    "render link to 'choice' page" when {
+    "render link to 'find consignment' page" in {
 
-      "config does not contain feature switch" in {
-
-        val linkView = linkComponent()
-          .getElementsByClass("govuk-link")
-          .first()
-        linkView must haveHref(controllers.routes.ChoiceController.displayPage())
-        linkView must containMessage("movement.confirmation.redirect.choice.link")
-      }
-
-      "config contains 'ileQuery' feature switch OFF" in {
-
-        when(appConfig.hasIleQueryFeature).thenReturn(false)
-
-        val linkView = linkComponent()
-          .getElementsByClass("govuk-link")
-          .first()
-        linkView must haveHref(controllers.routes.ChoiceController.displayPage())
-        linkView must containMessage("movement.confirmation.redirect.choice.link")
-      }
-
-    }
-
-    "render link to 'find consignment' page" when {
-
-      "config contains 'ileQuery' feature switch ON" in {
-
-        when(appConfig.hasIleQueryFeature).thenReturn(true)
-
-        val linkView = linkComponent()
-          .getElementsByClass("govuk-link")
-          .first()
-        linkView must haveHref(controllers.ileQuery.routes.IleQueryController.displayQueryForm())
-        linkView must containMessage("movement.confirmation.redirect.query.link")
-      }
+      val linkView = linkComponent()
+        .getElementsByClass("govuk-link")
+        .first()
+      linkView must haveHref(controllers.ileQuery.routes.IleQueryController.displayQueryForm())
+      linkView must containMessage("movement.confirmation.redirect.query.link")
 
     }
 


### PR DESCRIPTION
Updated to sync with the latest changes.

CEDS-2100 - Make searching for a consignment the first step in the service

The "Find a consignment" became the first step in the `customs-exports-internal-frontend` so that NCH operators can search for a consignment before acting on it. When a user logs in to the service, the first screen they see now is the search screen, and she/he cannot access the 'What do you want to do?' screen directly. If a user navigates away from the query page, it is possible to get back using the back button. There is a link to the consignment detail screen as well.