### PR TITLE
CEDS-2177 - Improvements to Queried UCR page

### DIFF
--- a/app/models/notifications/queries/IleQueryResponseExchangeData.scala
+++ b/app/models/notifications/queries/IleQueryResponseExchangeData.scala
@@ -43,7 +43,7 @@ object IleQueryResponseExchangeData {
   ) extends IleQueryResponseExchangeData {
     override val typ = IleQueryResponseExchangeType.SuccessfulResponseExchange
 
-    val sortedChildrenUcrs: Seq[UcrInfo] = (childDucrs ++ childMucrs).sortBy(_.entryStatus.flatMap(_.roe).getOrElse(ROECode.UnknownRoe))
+    val sortedChildrenUcrs: Seq[UcrInfo] = (childDucrs ++ childMucrs).sortBy(_.entryStatus.flatMap(_.roe).getOrElse(ROECode.NoneRoe))
   }
 
   object SuccessfulResponseExchangeData {

--- a/app/models/viewmodels/decoder/ROECode.scala
+++ b/app/models/viewmodels/decoder/ROECode.scala
@@ -43,7 +43,7 @@ object ROECode {
       NoControlRequired,
       RiskingNotPerformed,
       PrelodgePrefix,
-      UnknownRoe
+      UnknownRoe()
     )
 
   case object DocumentaryControl extends ROECode(code = "1", messageKey = "decoder.roe.DocumentaryControl", priority = 2)
@@ -52,7 +52,8 @@ object ROECode {
   case object NoControlRequired extends ROECode(code = "6", messageKey = "decoder.roe.NoControlRequired", priority = 6)
   case object RiskingNotPerformed extends ROECode(code = "0", messageKey = "decoder.roe.RiskingNotPerformed", priority = 4)
   case object PrelodgePrefix extends ROECode(code = "H", messageKey = "decoder.roe.PrelodgePrefix", priority = 5)
-  case object UnknownRoe extends ROECode(code = "", messageKey = "", priority = 100)
+  case class UnknownRoe(override val code: String = "") extends ROECode(code = code, messageKey = "ileCode.unknown", priority = 100)
+  case object NoneRoe extends ROECode(code = "", messageKey = "", priority = 101)
 
   implicit object ROECodeFormat extends Format[ROECode] {
     def reads(value: JsValue): JsResult[ROECode] = value match {
@@ -61,11 +62,10 @@ object ROECode {
           case Some(result) => JsSuccess(result)
           case None =>
             logger.warn(s"Unknown ROE code: $code")
-            JsSuccess(UnknownRoe)
+            JsSuccess(UnknownRoe(code))
         }
       case _ =>
-        logger.warn("Incorrect type")
-        JsSuccess(UnknownRoe)
+        JsSuccess(NoneRoe)
     }
 
     def writes(value: ROECode): JsString = JsString(value.code)

--- a/app/models/viewmodels/ilequery/IleQueryCodeConverter.scala
+++ b/app/models/viewmodels/ilequery/IleQueryCodeConverter.scala
@@ -21,30 +21,33 @@ import models.notifications.queries.Transport
 import models.viewmodels.decoder.{CodeWithMessageKey, Decoder, ROECode}
 import play.api.i18n.Messages
 import services.Countries.countryName
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, Empty, HtmlContent, Text}
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, HtmlContent, Text}
 
 @Singleton
 class IleQueryCodeConverter @Inject()(decoder: Decoder) {
 
-  private def htmlString(codeWithMessageKey: CodeWithMessageKey)(implicit messages: Messages) =
-    s"<strong>${codeWithMessageKey.code}</strong> - ${messages(codeWithMessageKey.messageKey)}"
+  private def htmlString(codeWithMessageKey: CodeWithMessageKey)(implicit messages: Messages): String =
+    htmlString(codeWithMessageKey.code, codeWithMessageKey.messageKey)
+
+  private def htmlString(code: String, messageKey: String)(implicit messages: Messages): String =
+    s"<strong>$code</strong> - ${messages(messageKey)}"
+
+  private def unknown(code: String)(implicit messages: Messages): Content =
+    HtmlContent(htmlString(code, "ileCode.unknown"))
 
   def inputCustomsStatus(code: String)(implicit messages: Messages): Content =
-    decoder.ics(code).map(icsCode => HtmlContent(htmlString(icsCode))).getOrElse(Empty)
+    decoder.ics(code).map(icsCode => HtmlContent(htmlString(icsCode))).getOrElse(unknown(code))
 
-  def routeOfEntry(roe: ROECode)(implicit messages: Messages): Content = roe match {
-    case ROECode.UnknownRoe => Text(messages("ileQueryResponse.route.unknown"))
-    case _                  => HtmlContent(htmlString(roe))
-  }
+  def routeOfEntry(roe: ROECode)(implicit messages: Messages): Content = HtmlContent(htmlString(roe))
 
   def statusOfEntryDucr(code: String)(implicit messages: Messages): Content =
-    decoder.ducrSoe(code).map(soeCode => HtmlContent(htmlString(soeCode))).getOrElse(Empty)
+    decoder.ducrSoe(code).map(soeCode => HtmlContent(htmlString(soeCode))).getOrElse(unknown(code))
 
   def statusOfEntryMucr(code: String)(implicit messages: Messages): Content =
-    decoder.mucrSoe(code).map(soeCode => HtmlContent(htmlString(soeCode))).getOrElse(Empty)
+    decoder.mucrSoe(code).map(soeCode => HtmlContent(htmlString(soeCode))).getOrElse(unknown(code))
 
   def statusOfEntryAll(code: String)(implicit messages: Messages): Content =
-    decoder.allSoe(code).map(soeCode => HtmlContent(htmlString(soeCode))).getOrElse(Empty)
+    decoder.allSoe(code).map(soeCode => HtmlContent(htmlString(soeCode))).getOrElse(unknown(code))
 
   def transport(transport: Transport): Content =
     Text((transport.transportId ++ transport.nationality.map(countryName)).mkString(", "))

--- a/app/views/components/ilequery/response_associated_consignments.scala.html
+++ b/app/views/components/ilequery/response_associated_consignments.scala.html
@@ -25,9 +25,8 @@
 @(associatedUcrs: Seq[UcrInfo])(implicit request: Request[_], messages: Messages)
 
 @if(associatedUcrs.size > 0) {
-    <div class="govuk-grid-column-full">
+    <div class="govuk-grid-column-full" id="associatedUcrs">
         @govukTable(Table(
-            attributes = Map("id" -> "associatedUcrs"),
             rows = associatedUcrs.zipWithIndex.map(indexedUcr => {
                 Seq(
                     TableRow(

--- a/app/views/components/ilequery/response_buttons.scala.html
+++ b/app/views/components/ilequery/response_buttons.scala.html
@@ -28,7 +28,7 @@
   <div>
       @govukButton(Button(content = Text(messages("ileQueryResponse.links.manageConsignment")), href = Some(routes.ChoiceController.displayPage().url)))
   </div>
-  <div>
+  <div class="govuk-body govuk-!-margin-bottom-9">
       @link(messages("ileQueryResponse.links.findConsignment"), controllers.ileQuery.routes.IleQueryController.displayQueryForm)
   </div>
 </div>

--- a/app/views/components/ilequery/response_ducr_summary.scala.html
+++ b/app/views/components/ilequery/response_ducr_summary.scala.html
@@ -26,11 +26,10 @@
 
 @(info: DucrInfo)(implicit request: Request[_], messages: Messages)
 
-<div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-column-two-thirds" id="ducrSummary">
     <h2 class="govuk-heading-m">@messages("ileQueryResponse.details")</h2>
 
     @govukSummaryList(SummaryList(
-        attributes = Map("id" -> "summary"),
         rows = Seq(
             SummaryListRow(
                 key = Key(
@@ -64,7 +63,7 @@
                     content = info.entryStatus.flatMap(_.ics).map(converter.inputCustomsStatus(_)).getOrElse(Empty)
                 )
             )
-        ).filterNot(row => row.key.content == Text(messages("ileQueryResponse.details.transport")) && row.value.content == Empty),
+        ).filterNot(_.value.content == Empty),
         classes = "govuk-!-margin-bottom-9"
     ))
 </div>

--- a/app/views/components/ilequery/response_ducr_summary.scala.html
+++ b/app/views/components/ilequery/response_ducr_summary.scala.html
@@ -26,7 +26,7 @@
 
 @(info: DucrInfo)(implicit request: Request[_], messages: Messages)
 
-<div class="govuk-grid-column-two-thirds" id="ducrSummary">
+<div class="govuk-grid-column-two-thirds" id="summary">
     <h2 class="govuk-heading-m">@messages("ileQueryResponse.details")</h2>
 
     @govukSummaryList(SummaryList(

--- a/app/views/components/ilequery/response_mucr_summary.scala.html
+++ b/app/views/components/ilequery/response_mucr_summary.scala.html
@@ -37,7 +37,7 @@
 
 @(info: MucrInfo)(implicit request: Request[_], messages: Messages)
 
-<div class="govuk-grid-column-two-thirds" id="mucrSummary">
+<div class="govuk-grid-column-two-thirds" id="summary">
     <h2 class="govuk-heading-m govuk-!-margin-top-5">@messages("ileQueryResponse.details")</h2>
 
     @govukSummaryList(SummaryList(

--- a/app/views/components/ilequery/response_mucr_summary.scala.html
+++ b/app/views/components/ilequery/response_mucr_summary.scala.html
@@ -37,11 +37,10 @@
 
 @(info: MucrInfo)(implicit request: Request[_], messages: Messages)
 
-<div class="govuk-grid-column-two-thirds">
+<div class="govuk-grid-column-two-thirds" id="mucrSummary">
     <h2 class="govuk-heading-m govuk-!-margin-top-5">@messages("ileQueryResponse.details")</h2>
 
     @govukSummaryList(SummaryList(
-        attributes = Map("id" -> "summary"),
         rows = Seq(
             SummaryListRow(
                 key = Key(
@@ -67,7 +66,7 @@
                     content = info.transport.map(converter.transport).getOrElse(Empty)
                 )
             )
-        ).filterNot(row => row.key.content == Text(messages("ileQueryResponse.details.transport")) && row.value.content == Empty),
+        ).filterNot(_.value.content == Empty),
         classes = "govuk-!-margin-bottom-9"
     ))
 </div>

--- a/app/views/components/ilequery/response_parent.scala.html
+++ b/app/views/components/ilequery/response_parent.scala.html
@@ -27,12 +27,11 @@
 @(parentMucr: Option[MucrInfo])(implicit request: Request[_], messages: Messages)
 
 @if(parentMucr.isDefined){
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds" id="parentConsignment">
         <h2 class="govuk-heading-m">@messages("ileQueryResponse.parent")</h2>
 
         @parentMucr.map(parent => {
             govukSummaryList(SummaryList(
-                attributes = Map("id" -> "parentConsignment"),
                 rows = Seq(
                     SummaryListRow(
                         key = Key(
@@ -58,7 +57,7 @@
                             content = parent.entryStatus.flatMap(_.soe).map(converter.statusOfEntryMucr(_)).getOrElse(Empty)
                         )
                     )
-                ).filterNot(row => row.key.content == Text(messages("ileQueryResponse.details.transport")) && row.value.content == Empty),
+                ).filterNot(_.value.content == Empty),
                 classes = "govuk-!-margin-bottom-9"
             ))
         })

--- a/app/views/components/ilequery/response_previous_movements.scala.html
+++ b/app/views/components/ilequery/response_previous_movements.scala.html
@@ -22,40 +22,41 @@
 
 @(movements: Seq[MovementInfo])(implicit request: Request[_], messages: Messages)
 
-<div class="govuk-grid-column-full">
-    @govukTable(Table(
-        attributes = Map("id" -> "previousMovements"),
-        rows = movements.sortBy(_.movementDateTime).reverse.zipWithIndex.map(indexedMovement => {
-            Seq(
-                TableRow(
-                    content = Text(messages(s"ileQueryResponse.previousMovements.type.${indexedMovement._1.messageCode.toLowerCase}")),
-                    attributes = Map("id" -> s"movement_type_${indexedMovement._2}")
-                ),
-                TableRow(
-                    content = Text(indexedMovement._1.movementDateTime.map(date => ViewDates.movementFormatter.format(date)).getOrElse("")),
-                    attributes = Map("id" -> s"movement_date_${indexedMovement._2}")
-                ),
-                TableRow(
-                    content = Text(indexedMovement._1.goodsLocation),
-                    attributes = Map("id" -> s"goods_location_${indexedMovement._2}")
+    @if(movements.nonEmpty) {
+        <div class="govuk-grid-column-full" id="previousMovements">
+        @govukTable(Table(
+            rows = movements.sortBy(_.movementDateTime).reverse.zipWithIndex.map(indexedMovement => {
+                Seq(
+                    TableRow(
+                        content = Text(messages(s"ileQueryResponse.previousMovements.type.${indexedMovement._1.messageCode.toLowerCase}")),
+                        attributes = Map("id" -> s"movement_type_${indexedMovement._2}")
+                    ),
+                    TableRow(
+                        content = Text(indexedMovement._1.movementDateTime.map(date => ViewDates.movementFormatter.format(date)).getOrElse("")),
+                        attributes = Map("id" -> s"movement_date_${indexedMovement._2}")
+                    ),
+                    TableRow(
+                        content = Text(indexedMovement._1.goodsLocation),
+                        attributes = Map("id" -> s"goods_location_${indexedMovement._2}")
+                    )
                 )
-            )
-        })
-        ,
-        head = Some(List(
-            HeadCell(
-                content = Text(messages("ileQueryResponse.previousMovements.type"))
-            ),
-            HeadCell(
-                content = Text(messages("ileQueryResponse.previousMovements.date"))
-            ),
-            HeadCell(
-                content = Text(messages("ileQueryResponse.previousMovements.goodsLocation"))
-            )
-        )),
-        classes = "govuk-table govuk-!-margin-bottom-9",
-        caption = Some(messages("ileQueryResponse.previousMovements")),
-        captionClasses = "govuk-table__caption govuk-heading-m",
-        firstCellIsHeader = true
-    ))
-</div>
+            })
+            ,
+            head = Some(List(
+                HeadCell(
+                    content = Text(messages("ileQueryResponse.previousMovements.type"))
+                ),
+                HeadCell(
+                    content = Text(messages("ileQueryResponse.previousMovements.date"))
+                ),
+                HeadCell(
+                    content = Text(messages("ileQueryResponse.previousMovements.goodsLocation"))
+                )
+            )),
+            classes = "govuk-table govuk-!-margin-bottom-9",
+            caption = Some(messages("ileQueryResponse.previousMovements")),
+            captionClasses = "govuk-table__caption govuk-heading-m",
+            firstCellIsHeader = true
+        ))
+        </div>
+    }

--- a/app/views/ile_query_ducr_response.scala.html
+++ b/app/views/ile_query_ducr_response.scala.html
@@ -50,11 +50,12 @@
 
         @summarySection(info)
 
+        @responseButtons()
+
         @previousMovementsSection(info.movements)
 
         @parentSection(parentMucr)
 
-        @responseButtons()
 
     </div>
 

--- a/app/views/ile_query_mucr_response.scala.html
+++ b/app/views/ile_query_mucr_response.scala.html
@@ -60,13 +60,13 @@
 
         @summarySection(info)
 
+        @responseButtons()
+
         @previousMovementsSection(info.movements)
 
         @parentSection(parentMucr)
 
         @associatedConsignmentsSection(associatedConsignments)
-
-        @responseButtons()
 
     </div>
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -361,4 +361,4 @@ ileQueryResponse.links.findConsignment = Find another consignment
 ileQueryResponse.ucrNotFound.title = The requested UCR does not exist
 ileQueryResponse.ucrNotFound.message = {0} does not exist.
 
-ileQueryResponse.route.unknown = Unknown
+ileCode.unknown = Unknown

--- a/test/unit/models/viewmodels/decoder/ROECodeSpec.scala
+++ b/test/unit/models/viewmodels/decoder/ROECodeSpec.scala
@@ -40,7 +40,7 @@ class ROECodeSpec extends UnitSpec {
           NoControlRequired,
           RiskingNotPerformed,
           PrelodgePrefix,
-          UnknownRoe
+          UnknownRoe()
         )
 
       ROECode.codes mustBe expectedCodes
@@ -54,7 +54,8 @@ class ROECodeSpec extends UnitSpec {
       NoControlRequired.priority mustBe 6
       RiskingNotPerformed.priority mustBe 4
       PrelodgePrefix.priority mustBe 5
-      UnknownRoe.priority mustBe 100
+      UnknownRoe().priority mustBe 100
+      NoneRoe.priority mustBe 101
     }
 
     "parse ROE Code" when {
@@ -69,12 +70,12 @@ class ROECodeSpec extends UnitSpec {
 
       "code is incorrect" in {
 
-        ROECode.ROECodeFormat.reads(JsString("incorrect")) mustBe JsSuccess(UnknownRoe)
+        ROECode.ROECodeFormat.reads(JsString("incorrect")) mustBe JsSuccess(UnknownRoe("incorrect"))
       }
 
       "type of the code is incorrect" in {
 
-        ROECode.ROECodeFormat.reads(JsNumber(1)) mustBe JsSuccess(UnknownRoe)
+        ROECode.ROECodeFormat.reads(JsNumber(1)) mustBe JsSuccess(NoneRoe)
       }
     }
 

--- a/test/unit/models/viewmodels/notificationspage/converters/EMRResponseConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/EMRResponseConverterSpec.scala
@@ -142,14 +142,14 @@ class EMRResponseConverterSpec extends UnitSpec with BeforeAndAfterEach {
         contentBuilder.convert(input)
 
         verify(decoder).crc(meq(UnknownCrcCode))
-        verify(decoder).roe(meq(UnknownRoeCode.code))
+        verify(decoder).roe(meq(UnknownRoeCode().code))
         verify(decoder).mucrSoe(meq(UnknownMucrSoeCode))
       }
 
       "return NotificationsPageSingleElement without content for unknown codes" in {
 
         when(decoder.crc(meq(UnknownCrcCode))).thenReturn(None)
-        when(decoder.roe(meq(UnknownRoeCode.code))).thenReturn(None)
+        when(decoder.roe(meq(UnknownRoeCode().code))).thenReturn(None)
         when(decoder.mucrSoe(meq(UnknownMucrSoeCode))).thenReturn(None)
 
         val input = emrResponseUnknownCodes
@@ -206,7 +206,7 @@ object EMRResponseConverterSpec {
     entries = Seq(
       Entry(
         ucrBlock = Some(UcrBlock(ucr = correctUcr, ucrType = "M")),
-        entryStatus = Some(EntryStatus(roe = Some(UnknownRoeCode), soe = Some(UnknownMucrSoeCode)))
+        entryStatus = Some(EntryStatus(roe = Some(UnknownRoeCode()), soe = Some(UnknownMucrSoeCode)))
       )
     )
   )

--- a/test/unit/models/viewmodels/notificationspage/converters/ERSResponseConverterSpec.scala
+++ b/test/unit/models/viewmodels/notificationspage/converters/ERSResponseConverterSpec.scala
@@ -142,14 +142,14 @@ class ERSResponseConverterSpec extends UnitSpec with BeforeAndAfterEach {
         contentBuilder.convert(input)
 
         verify(decoder).ics(meq(UnknownIcsCode))
-        verify(decoder).roe(meq(UnknownRoeCode.code))
+        verify(decoder).roe(meq(UnknownRoeCode().code))
         verify(decoder).ducrSoe(meq(UnknownSoeCode))
       }
 
       "return NotificationsPageSingleElement without content for unknown codes" in {
 
         when(decoder.ics(meq(UnknownIcsCode))).thenReturn(None)
-        when(decoder.roe(meq(UnknownRoeCode.code))).thenReturn(None)
+        when(decoder.roe(meq(UnknownRoeCode().code))).thenReturn(None)
         when(decoder.ducrSoe(meq(UnknownSoeCode))).thenReturn(None)
 
         val input = ersResponseUnknownCodes
@@ -205,7 +205,7 @@ object ERSResponseConverterSpec {
     entries = Seq(
       Entry(
         ucrBlock = Some(UcrBlock(ucr = correctUcr, ucrType = "D")),
-        entryStatus = Some(EntryStatus(ics = Some(UnknownIcsCode), roe = Some(UnknownRoeCode), soe = Some(UnknownSoeCode)))
+        entryStatus = Some(EntryStatus(ics = Some(UnknownIcsCode), roe = Some(UnknownRoeCode()), soe = Some(UnknownSoeCode)))
       )
     )
   )

--- a/test/unit/views/IleQueryDucrResponseViewSpec.scala
+++ b/test/unit/views/IleQueryDucrResponseViewSpec.scala
@@ -16,16 +16,11 @@
 
 package views
 
-import java.time.ZonedDateTime
-
 import base.Injector
 import models.notifications.EntryStatus
 import models.notifications.queries.{DucrInfo, MovementInfo, MucrInfo}
-import models.viewmodels.decoder.ROECode.UnknownRoe
-import models.viewmodels.decoder.{ICSCode, ROECode, SOECode}
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.FakeRequest
-import play.twirl.api.Html
 import views.html.ile_query_ducr_response
 
 class IleQueryDucrResponseViewSpec extends ViewSpec with Injector {
@@ -34,122 +29,29 @@ class IleQueryDucrResponseViewSpec extends ViewSpec with Injector {
 
   private val page = instanceOf[ile_query_ducr_response]
 
-  val arrival =
-    MovementInfo(messageCode = "EAL", goodsLocation = "GBAUFXTFXTFXT", movementDateTime = Some(ZonedDateTime.parse("2019-10-23T12:34:18Z").toInstant))
-  val retro =
-    MovementInfo(messageCode = "RET", goodsLocation = "GBAUDFGFSHFKD", movementDateTime = Some(ZonedDateTime.parse("2019-11-04T16:27:18Z").toInstant))
-  val depart = MovementInfo(
-    messageCode = "EDL",
-    goodsLocation = "GBAUFDSASFDFDF",
-    movementDateTime = Some(ZonedDateTime.parse("2019-10-30T09:17:18Z").toInstant)
-  )
-
   val status = EntryStatus(Some("ICS"), None, Some("SOE"))
-  val ducrInfo =
-    DucrInfo(ucr = "8GB123458302100-101SHIP1", declarationId = "121332435432", movements = Seq.empty, entryStatus = Some(status))
+  val movement = MovementInfo("EAL", "goods")
+  val ducrInfo = DucrInfo(ucr = "ducr", declarationId = "id", movements = Seq(movement), entryStatus = Some(status))
+  val parentInfo = MucrInfo("parentUcr")
 
   private def view(info: DucrInfo = ducrInfo, parent: Option[MucrInfo] = None) = page(info, parent)
-
-  private def summaryElement(html: Html, index: Int) = html.getElementById("summary").select(s"div:eq($index)>dd").get(0)
-  private def parentConsignmentElement(html: Html, index: Int) = html.getElementById("parentConsignment").select(s"div:eq($index)>dd").get(0)
 
   "Ile Query page" should {
 
     "render title" in {
-
       view().getTitle must containMessage("ileQueryResponse.ducr.title")
     }
 
-    "render arrival movement" in {
-      val arrivalView = view(ducrInfo.copy(movements = Seq(arrival)))
-      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.eal")
-      arrivalView.getElementById("movement_date_0").text() must be("23 October 2019 at 13:34")
-      arrivalView.getElementById("goods_location_0").text() must be("GBAUFXTFXTFXT")
+    "render queried ucr summary" in {
+      view().getElementById("ducrSummary") must containMessage("ileQueryResponse.details")
     }
 
-    "render departure movement" in {
-      val arrivalView = view(ducrInfo.copy(movements = Seq(depart)))
-      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.edl")
-      arrivalView.getElementById("movement_date_0").text() must be("30 October 2019 at 09:17")
-      arrivalView.getElementById("goods_location_0").text() must be("GBAUFDSASFDFDF")
+    "render previous movements" in {
+      view().getElementById("previousMovements") must containMessage("ileQueryResponse.previousMovements")
     }
 
-    "render retrospective arrival" in {
-      val arrivalView = view(ducrInfo.copy(movements = Seq(retro)))
-      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.ret")
-      arrivalView.getElementById("movement_date_0").text() must be("4 November 2019 at 16:27")
-      arrivalView.getElementById("goods_location_0").text() must be("GBAUDFGFSHFKD")
-    }
-
-    "render movements by date order" in {
-      val movementsView = view(ducrInfo.copy(movements = Seq(arrival, retro, depart)))
-      movementsView.getElementById("movement_date_0").text() must be("4 November 2019 at 16:27")
-      movementsView.getElementById("movement_date_1").text() must be("30 October 2019 at 09:17")
-      movementsView.getElementById("movement_date_2").text() must be("23 October 2019 at 13:34")
-    }
-
-    "render no route of entry" in {
-      summaryElement(view(), 0).text must be("")
-    }
-
-    "render unknown route of entry" in {
-      summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(roe = Some(UnknownRoe))))), 0) must containMessage(
-        "ileQueryResponse.route.unknown"
-      )
-    }
-
-    "translate all routes of entry" in {
-      ROECode.codes
-        .filterNot(_ == UnknownRoe)
-        .foreach(roe => summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(roe = Some(roe))))), 0) must containMessage(roe.messageKey))
-    }
-
-    "render default status of entry" in {
-      summaryElement(view(), 1).text must be("")
-    }
-
-    "render empty status of entry" in {
-      summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(soe = None)))), 1).text must be("")
-    }
-
-    "translate all ducr status of entry" in {
-      SOECode.DucrCodes.foreach(
-        soe => summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(soe = Some(soe.code))))), 1) must containMessage(soe.messageKey)
-      )
-    }
-
-    "render default input customs status" in {
-      summaryElement(view(), 2).text must be("")
-    }
-
-    "render empty input customs status" in {
-      summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(ics = None)))), 2).text must be("")
-    }
-
-    "translate all input customs status" in {
-      ICSCode.codes.foreach(
-        ics => summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(ics = Some(ics.code))))), 2) must containMessage(ics.messageKey)
-      )
-    }
-
-    val viewWithParent = view(
-      parent =
-        Some(MucrInfo("parentUcr", entryStatus = Some(EntryStatus(None, Some(ROECode.DocumentaryControl), Some(SOECode.ConsolidationOpen.code)))))
-    )
-
-    "render parent consignment link" in {
-      parentConsignmentElement(viewWithParent, 0).getElementsByClass("govuk-link").first() must haveHref(
-        controllers.ileQuery.routes.IleQueryController.submitQuery("parentUcr")
-      )
-      parentConsignmentElement(viewWithParent, 0).text() must be("parentUcr")
-    }
-
-    "render parent consignment route" in {
-      parentConsignmentElement(viewWithParent, 1) must containMessage(ROECode.DocumentaryControl.messageKey)
-    }
-
-    "render parent consignment status" in {
-      parentConsignmentElement(viewWithParent, 2) must containMessage(SOECode.ConsolidationOpen.messageKey)
+    "render parent" in {
+      view(parent = Some(parentInfo)).getElementById("parentConsignment") must containMessage("ileQueryResponse.parent")
     }
   }
 }

--- a/test/unit/views/IleQueryDucrResponseViewSpec.scala
+++ b/test/unit/views/IleQueryDucrResponseViewSpec.scala
@@ -43,7 +43,7 @@ class IleQueryDucrResponseViewSpec extends ViewSpec with Injector {
     }
 
     "render queried ucr summary" in {
-      view().getElementById("ducrSummary") must containMessage("ileQueryResponse.details")
+      view().getElementById("summary") must containMessage("ileQueryResponse.details")
     }
 
     "render previous movements" in {

--- a/test/unit/views/IleQueryMucrResponseViewSpec.scala
+++ b/test/unit/views/IleQueryMucrResponseViewSpec.scala
@@ -16,16 +16,10 @@
 
 package views
 
-import java.time.ZonedDateTime
-
 import base.Injector
-import models.notifications.EntryStatus
 import models.notifications.queries.{MovementInfo, MucrInfo, UcrInfo}
-import models.viewmodels.decoder.ROECode.UnknownRoe
-import models.viewmodels.decoder.{ROECode, SOECode}
 import play.api.mvc.{AnyContent, Request}
 import play.api.test.FakeRequest
-import play.twirl.api.Html
 import views.html.ile_query_mucr_response
 
 class IleQueryMucrResponseViewSpec extends ViewSpec with Injector {
@@ -34,89 +28,34 @@ class IleQueryMucrResponseViewSpec extends ViewSpec with Injector {
 
   private val page = instanceOf[ile_query_mucr_response]
 
-  val arrival =
-    MovementInfo(messageCode = "EAL", goodsLocation = "GBAUFXTFXTFXT", movementDateTime = Some(ZonedDateTime.parse("2019-10-23T12:34:18Z").toInstant))
-  val retro =
-    MovementInfo(messageCode = "RET", goodsLocation = "GBAUDFGFSHFKD", movementDateTime = Some(ZonedDateTime.parse("2019-11-01T02:34:18Z").toInstant))
-  val depart = MovementInfo(
-    messageCode = "EDL",
-    goodsLocation = "GBAUFDSASFDFDF",
-    movementDateTime = Some(ZonedDateTime.parse("2019-10-30T10:22:18Z").toInstant)
-  )
-
-  val status = EntryStatus(Some("ICS"), None, Some("SOE"))
-  val mucrInfo =
-    MucrInfo(ucr = "8GB123458302100-101SHIP1", movements = Seq.empty, entryStatus = Some(status), isShut = Some(true))
+  val movement = MovementInfo("EAL", "goods")
+  val mucrInfo = MucrInfo(ucr = "mucr", movements = Seq(movement), isShut = Some(true))
+  val parentInfo = MucrInfo("parentUcr")
+  val associatedInfo = MucrInfo("childUcr")
 
   private def view(info: MucrInfo = mucrInfo, parent: Option[MucrInfo] = None, associatedConsignments: Seq[UcrInfo] = Seq.empty) =
     page(info, parent, associatedConsignments)
 
-  private def summaryElement(html: Html, index: Int) = html.getElementById("summary").select(s"div:eq($index)>dd").get(0)
-  private def parentConsignmentElement(html: Html, index: Int) = html.getElementById("parentConsignment").select(s"div:eq($index)>dd").get(0)
-
   "Ile Query page" should {
 
     "render title" in {
-
       view().getTitle must containMessage("ileQueryResponse.ducr.title")
     }
 
-    "render arrival movement" in {
-      val arrivalView = view(mucrInfo.copy(movements = Seq(arrival)))
-      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.eal")
-      arrivalView.getElementById("movement_date_0").text() must be("23 October 2019 at 13:34")
-      arrivalView.getElementById("goods_location_0").text() must be("GBAUFXTFXTFXT")
+    "render queried ucr summary" in {
+      view().getElementById("mucrSummary") must containMessage("ileQueryResponse.details")
     }
 
-    "render departure movement" in {
-      val arrivalView = view(mucrInfo.copy(movements = Seq(depart)))
-      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.edl")
-      arrivalView.getElementById("movement_date_0").text() must be("30 October 2019 at 10:22")
-      arrivalView.getElementById("goods_location_0").text() must be("GBAUFDSASFDFDF")
+    "render previous movements" in {
+      view().getElementById("previousMovements") must containMessage("ileQueryResponse.previousMovements")
     }
 
-    "render retrospective arrival" in {
-      val arrivalView = view(mucrInfo.copy(movements = Seq(retro)))
-      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.ret")
-      arrivalView.getElementById("movement_date_0").text() must be("1 November 2019 at 02:34")
-      arrivalView.getElementById("goods_location_0").text() must be("GBAUDFGFSHFKD")
+    "render parent" in {
+      view(parent = Some(parentInfo)).getElementById("parentConsignment") must containMessage("ileQueryResponse.parent")
     }
 
-    "render movements by date order" in {
-      val movementsView = view(mucrInfo.copy(movements = Seq(arrival, retro, depart)))
-      movementsView.getElementById("movement_date_0").text() must be("1 November 2019 at 02:34")
-      movementsView.getElementById("movement_date_1").text() must be("30 October 2019 at 10:22")
-      movementsView.getElementById("movement_date_2").text() must be("23 October 2019 at 13:34")
-    }
-
-    "render no route of entry" in {
-      summaryElement(view(), 0).text must be("")
-    }
-
-    "render unknown route of entry" in {
-      summaryElement(view(mucrInfo.copy(entryStatus = Some(status.copy(roe = Some(UnknownRoe))))), 0) must containMessage(
-        "ileQueryResponse.route.unknown"
-      )
-    }
-
-    "translate all routes of entry" in {
-      ROECode.codes
-        .filterNot(_ == UnknownRoe)
-        .foreach(roe => summaryElement(view(mucrInfo.copy(entryStatus = Some(status.copy(roe = Some(roe))))), 0) must containMessage(roe.messageKey))
-    }
-
-    "render default status of entry" in {
-      summaryElement(view(), 1).text must be("")
-    }
-
-    "render empty status of entry" in {
-      summaryElement(view(mucrInfo.copy(entryStatus = Some(status.copy(soe = None)))), 1).text must be("")
-    }
-
-    "translate all status of entry" in {
-      SOECode.MucrCodes.foreach(
-        soe => summaryElement(view(mucrInfo.copy(entryStatus = Some(status.copy(soe = Some(soe.code))))), 1) must containMessage(soe.messageKey)
-      )
+    "render associated consignments" in {
+      view(associatedConsignments = Seq(associatedInfo)).getElementById("associatedUcrs") must containMessage("ileQueryResponse.associated")
     }
 
     "render isShut when mucr shut" in {
@@ -135,44 +74,5 @@ class IleQueryMucrResponseViewSpec extends ViewSpec with Injector {
       view(info = mucrInfo.copy(isShut = Some(true)), parent = Some(MucrInfo("mucr"))).getElementById("isShutMucr") must be(null)
     }
 
-    val viewWithParent = view(
-      parent =
-        Some(MucrInfo("parentUcr", entryStatus = Some(EntryStatus(None, Some(ROECode.DocumentaryControl), Some(SOECode.ConsolidationOpen.code)))))
-    )
-
-    "render parent consignment link" in {
-      parentConsignmentElement(viewWithParent, 0).getElementsByClass("govuk-link").first() must haveHref(
-        controllers.ileQuery.routes.IleQueryController.submitQuery("parentUcr")
-      )
-      parentConsignmentElement(viewWithParent, 0) must containText("parentUcr")
-    }
-
-    "render parent consignment route" in {
-      parentConsignmentElement(viewWithParent, 1) must containMessage(ROECode.DocumentaryControl.messageKey)
-    }
-
-    "render parent consignment status" in {
-      parentConsignmentElement(viewWithParent, 2) must containMessage(SOECode.ConsolidationOpen.messageKey)
-    }
-
-    "not render associate consignments section if there aren't any " in {
-      view().getElementById("associatedUcrs") must be(null)
-    }
-
-    "render associate consignments section" in {
-      val viewWithChild = view(
-        associatedConsignments =
-          Seq(MucrInfo("childUcr", entryStatus = Some(EntryStatus(None, Some(ROECode.DocumentaryControl), Some(SOECode.Departed.code)))))
-      )
-      viewWithChild.getElementById("associatedUcrs") must containMessage("ileQueryResponse.associated")
-
-      val elmChild = viewWithChild.getElementById("associateUcr_0_ucr")
-      elmChild must containText("childUcr")
-      elmChild.getElementsByClass("govuk-link").first() must haveHref(controllers.ileQuery.routes.IleQueryController.submitQuery("childUcr"))
-
-      viewWithChild.getElementById("associateUcr_0_roe") must containMessage(ROECode.DocumentaryControl.messageKey)
-
-      viewWithChild.getElementById("associateUcr_0_soe") must containMessage(SOECode.Departed.messageKey)
-    }
   }
 }

--- a/test/unit/views/IleQueryMucrResponseViewSpec.scala
+++ b/test/unit/views/IleQueryMucrResponseViewSpec.scala
@@ -43,7 +43,7 @@ class IleQueryMucrResponseViewSpec extends ViewSpec with Injector {
     }
 
     "render queried ucr summary" in {
-      view().getElementById("mucrSummary") must containMessage("ileQueryResponse.details")
+      view().getElementById("summary") must containMessage("ileQueryResponse.details")
     }
 
     "render previous movements" in {

--- a/test/unit/views/components/ilequery/AssociatedConsignmentsViewSpec.scala
+++ b/test/unit/views/components/ilequery/AssociatedConsignmentsViewSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.ilequery
+
+import base.Injector
+import models.notifications.EntryStatus
+import models.notifications.queries.{MucrInfo, UcrInfo}
+import models.viewmodels.decoder.{ROECode, SOECode}
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import views.ViewSpec
+import views.html.components.ilequery.response_associated_consignments
+
+class AssociatedConsignmentsViewSpec extends ViewSpec with Injector {
+
+  private implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  private val page = instanceOf[response_associated_consignments]
+
+  private def view(associatedConsignments: Seq[UcrInfo] = Seq.empty) = page(associatedConsignments)
+
+  "Associated consignment " should {
+
+    "not render for empty associated consignments list" in {
+
+      view().getElementById("associatedUcrs") must be(null)
+      view().text() mustBe ""
+    }
+
+    "render associate consignments section" in {
+      val viewWithChild = view(
+        associatedConsignments =
+          Seq(MucrInfo("childUcr", entryStatus = Some(EntryStatus(None, Some(ROECode.DocumentaryControl), Some(SOECode.Departed.code)))))
+      )
+      viewWithChild.getElementById("associatedUcrs") must containMessage("ileQueryResponse.associated")
+
+      val elmChild = viewWithChild.getElementById("associateUcr_0_ucr")
+      elmChild must containText("childUcr")
+      elmChild.getElementsByClass("govuk-link").first() must haveHref(controllers.ileQuery.routes.IleQueryController.submitQuery("childUcr"))
+
+      viewWithChild.getElementById("associateUcr_0_roe") must containMessage(ROECode.DocumentaryControl.messageKey)
+
+      viewWithChild.getElementById("associateUcr_0_soe") must containMessage(SOECode.Departed.messageKey)
+    }
+  }
+}

--- a/test/unit/views/components/ilequery/DucrSummaryViewSpec.scala
+++ b/test/unit/views/components/ilequery/DucrSummaryViewSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.ilequery
+
+import base.Injector
+import models.notifications.EntryStatus
+import models.notifications.queries.{DucrInfo, MovementInfo, Transport}
+import models.viewmodels.decoder.ROECode.UnknownRoe
+import models.viewmodels.decoder.{ICSCode, ROECode, SOECode}
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import views.ViewSpec
+import views.html.components.ilequery.response_ducr_summary
+
+class DucrSummaryViewSpec extends ViewSpec with Injector {
+
+  private implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  private val page = instanceOf[response_ducr_summary]
+
+  val status = EntryStatus(Some(ICSCode.InvalidationByCustoms.code), Some(ROECode.DocumentaryControl), Some(SOECode.DeclarationValidation.code))
+  val movement =
+    MovementInfo("", "", transportDetails = Some(Transport(modeOfTransport = Some("mode"), nationality = Some("FR"), transportId = Some("WagonId"))))
+  val ducrInfo =
+    DucrInfo(ucr = "ducr", declarationId = "121332435432", movements = Seq(movement), entryStatus = Some(status))
+
+  private def summaryElement(html: Html, index: Int) = html.getElementById("ducrSummary").select(s"dl>div:eq($index)>dd").get(0)
+
+  private def view(ducr: DucrInfo = ducrInfo) = page(ducr)
+
+  "Ducr summary" should {
+
+    "render all routes of entry" in {
+      ROECode.codes
+        .filterNot(_ == UnknownRoe)
+        .foreach(roe => summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(roe = Some(roe))))), 0) must containMessage(roe.messageKey))
+    }
+
+    "render unknown route of entry" in {
+      val summaryView = view(ducrInfo.copy(entryStatus = Some(status.copy(roe = Some(UnknownRoe())))))
+      summaryElement(summaryView, 0) must containMessage("ileCode.unknown")
+    }
+
+    "render all ducr status of entry" in {
+      SOECode.DucrCodes.foreach(
+        soe => summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(soe = Some(soe.code))))), 1) must containMessage(soe.messageKey)
+      )
+    }
+
+    "render unknown status of entry" in {
+      val summaryView = view(ducrInfo.copy(entryStatus = Some(status.copy(soe = Some("unknown")))))
+      summaryElement(summaryView, 1) must containMessage("ileCode.unknown")
+    }
+
+    "render transport" in {
+      summaryElement(view(), 2).text() must include("WagonId, France")
+    }
+
+    "render all input customs status" in {
+      ICSCode.codes.foreach(
+        ics => summaryElement(view(ducrInfo.copy(entryStatus = Some(status.copy(ics = Some(ics.code))))), 3) must containMessage(ics.messageKey)
+      )
+    }
+
+    "render unknown input customs status" in {
+      val summaryView = view(ducrInfo.copy(entryStatus = Some(status.copy(ics = Some("unknown")))))
+      summaryElement(summaryView, 3) must containMessage("ileCode.unknown")
+    }
+
+    "render all rows" in {
+      val summaryText = view().text()
+      summaryText must include("Route")
+      summaryText must include("Status")
+      summaryText must include("Transport")
+      summaryText must include("Input status")
+    }
+
+    "not render rows when codes and transport missing" in {
+      val summaryText = view(ducrInfo.copy(entryStatus = None, movements = Seq.empty)).text()
+      summaryText must not include ("Route")
+      summaryText must not include ("Status")
+      summaryText must not include ("Transport")
+      summaryText must not include ("Input status")
+    }
+
+  }
+
+}

--- a/test/unit/views/components/ilequery/DucrSummaryViewSpec.scala
+++ b/test/unit/views/components/ilequery/DucrSummaryViewSpec.scala
@@ -39,7 +39,7 @@ class DucrSummaryViewSpec extends ViewSpec with Injector {
   val ducrInfo =
     DucrInfo(ucr = "ducr", declarationId = "121332435432", movements = Seq(movement), entryStatus = Some(status))
 
-  private def summaryElement(html: Html, index: Int) = html.getElementById("ducrSummary").select(s"dl>div:eq($index)>dd").get(0)
+  private def summaryElement(html: Html, index: Int) = html.getElementById("summary").select(s"dl>div:eq($index)>dd").get(0)
 
   private def view(ducr: DucrInfo = ducrInfo) = page(ducr)
 

--- a/test/unit/views/components/ilequery/MucrSummaryViewSpec.scala
+++ b/test/unit/views/components/ilequery/MucrSummaryViewSpec.scala
@@ -39,7 +39,7 @@ class MucrSummaryViewSpec extends ViewSpec with Injector {
   val mucrInfo =
     MucrInfo(ucr = "mucr", movements = Seq(movement), entryStatus = Some(status), isShut = Some(true))
 
-  private def summaryElement(html: Html, index: Int) = html.getElementById("mucrSummary").select(s"dl>div:eq($index)>dd").get(0)
+  private def summaryElement(html: Html, index: Int) = html.getElementById("summary").select(s"dl>div:eq($index)>dd").get(0)
 
   private def view(mucr: MucrInfo = mucrInfo) = page(mucr)
 

--- a/test/unit/views/components/ilequery/MucrSummaryViewSpec.scala
+++ b/test/unit/views/components/ilequery/MucrSummaryViewSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.ilequery
+
+import base.Injector
+import models.notifications.EntryStatus
+import models.notifications.queries.{DucrInfo, MovementInfo, MucrInfo, Transport}
+import models.viewmodels.decoder.ROECode.UnknownRoe
+import models.viewmodels.decoder.{ICSCode, ROECode, SOECode}
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import views.ViewSpec
+import views.html.components.ilequery.response_mucr_summary
+
+class MucrSummaryViewSpec extends ViewSpec with Injector {
+
+  private implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  private val page = instanceOf[response_mucr_summary]
+
+  val status = EntryStatus(Some(ICSCode.InvalidationByCustoms.code), Some(ROECode.DocumentaryControl), Some(SOECode.DeclarationValidation.code))
+  val movement =
+    MovementInfo("", "", transportDetails = Some(Transport(modeOfTransport = Some("mode"), nationality = Some("FR"), transportId = Some("WagonId"))))
+  val mucrInfo =
+    MucrInfo(ucr = "mucr", movements = Seq(movement), entryStatus = Some(status), isShut = Some(true))
+
+  private def summaryElement(html: Html, index: Int) = html.getElementById("mucrSummary").select(s"dl>div:eq($index)>dd").get(0)
+
+  private def view(mucr: MucrInfo = mucrInfo) = page(mucr)
+
+  "Mucr summary" should {
+
+    "render all routes of entry" in {
+      ROECode.codes
+        .filterNot(_ == UnknownRoe)
+        .foreach(roe => summaryElement(view(mucrInfo.copy(entryStatus = Some(status.copy(roe = Some(roe))))), 0) must containMessage(roe.messageKey))
+    }
+
+    "render unknown route of entry" in {
+      val summaryView = view(mucrInfo.copy(entryStatus = Some(status.copy(roe = Some(UnknownRoe())))))
+      summaryElement(summaryView, 0) must containMessage("ileCode.unknown")
+    }
+
+    "render all mucr status of entry" in {
+      SOECode.MucrCodes.foreach(
+        soe => summaryElement(view(mucrInfo.copy(entryStatus = Some(status.copy(soe = Some(soe.code))))), 1) must containMessage(soe.messageKey)
+      )
+    }
+
+    "render unknown status of entry" in {
+      val summaryView = view(mucrInfo.copy(entryStatus = Some(status.copy(soe = Some("unknown")))))
+      summaryElement(summaryView, 1) must containMessage("ileCode.unknown")
+    }
+
+    "render transport" in {
+      summaryElement(view(), 2).text() must include("WagonId, France")
+    }
+
+    "render all rows" in {
+      val summaryText = view().text()
+      summaryText must include("Route")
+      summaryText must include("Status")
+      summaryText must include("Transport")
+    }
+
+    "not render rows when codes and transport missing" in {
+      val summaryText = view(mucrInfo.copy(entryStatus = None, movements = Seq.empty)).text()
+      summaryText must not include ("Route")
+      summaryText must not include ("Status")
+      summaryText must not include ("Transport")
+    }
+
+  }
+
+}

--- a/test/unit/views/components/ilequery/ParentViewSpec.scala
+++ b/test/unit/views/components/ilequery/ParentViewSpec.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.ilequery
+
+import base.Injector
+import models.notifications.EntryStatus
+import models.notifications.queries.MucrInfo
+import models.viewmodels.decoder.{ROECode, SOECode}
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import play.twirl.api.Html
+import views.ViewSpec
+import views.html.components.ilequery.response_parent
+
+class ParentViewSpec extends ViewSpec with Injector {
+
+  private implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  private val page = instanceOf[response_parent]
+
+  private def view(parent: Option[MucrInfo] = None) = page(parent)
+
+  val parent = Some(
+    MucrInfo("parentUcr", entryStatus = Some(EntryStatus(None, Some(ROECode.DocumentaryControl), Some(SOECode.ConsolidationOpen.code))))
+  )
+
+  val parentNoEntryStatus = Some(MucrInfo("parentUcr", None))
+
+  private def parentElement(html: Html, index: Int) = html.getElementById("parentConsignment").select(s"dl>div:eq($index)>dd").get(0)
+
+  "Parent view" should {
+
+    "not render when no parent" in {
+
+      view().text() mustBe ""
+    }
+
+    "render parent consignment link" in {
+      val parentRefElement = parentElement(view(parent), 0)
+
+      parentRefElement.getElementsByClass("govuk-link").first() must haveHref(controllers.ileQuery.routes.IleQueryController.submitQuery("parentUcr"))
+      parentRefElement.text() must be("parentUcr")
+    }
+
+    "render parent consignment route" in {
+      val parentRouteElement = parentElement(view(parent), 1)
+
+      parentRouteElement.text() must not include "Route"
+      parentRouteElement must containMessage(ROECode.DocumentaryControl.messageKey)
+    }
+
+    "render parent consignment status" in {
+      val parentStatusElement = parentElement(view(parent), 2)
+
+      parentStatusElement.text() must not include "Input status"
+      parentStatusElement must containMessage(SOECode.ConsolidationOpen.messageKey)
+    }
+
+    "not render rows when status is missing" in {
+      val text = view(parentNoEntryStatus).text()
+      text must include("parentUcr")
+      text must not include ("Route")
+      text must not include ("Input status")
+    }
+  }
+}

--- a/test/unit/views/components/ilequery/PreviousMovementsViewSpec.scala
+++ b/test/unit/views/components/ilequery/PreviousMovementsViewSpec.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.ilequery
+
+import java.time.ZonedDateTime
+
+import base.Injector
+import models.notifications.queries.MovementInfo
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.FakeRequest
+import views.ViewSpec
+import views.html.components.ilequery.response_previous_movements
+
+class PreviousMovementsViewSpec extends ViewSpec with Injector {
+
+  private implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  private val page = instanceOf[response_previous_movements]
+
+  private def view(movements: Seq[MovementInfo] = Seq.empty) = page(movements)
+
+  val arrival =
+    MovementInfo(messageCode = "EAL", goodsLocation = "GBAUFXTFXTFXT", movementDateTime = Some(ZonedDateTime.parse("2019-10-23T12:34:18Z").toInstant))
+  val retro =
+    MovementInfo(messageCode = "RET", goodsLocation = "GBAUDFGFSHFKD", movementDateTime = Some(ZonedDateTime.parse("2019-11-04T16:27:18Z").toInstant))
+  val depart = MovementInfo(
+    messageCode = "EDL",
+    goodsLocation = "GBAUFDSASFDFDF",
+    movementDateTime = Some(ZonedDateTime.parse("2019-10-30T09:17:18Z").toInstant)
+  )
+
+  "Previous movements " should {
+
+    "not render for empty movement list" in {
+
+      view().text() mustBe ""
+    }
+
+    "render arrival movement" in {
+      val arrivalView = view(movements = Seq(arrival))
+      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.eal")
+      arrivalView.getElementById("movement_date_0").text() must be("23 October 2019 at 13:34")
+      arrivalView.getElementById("goods_location_0").text() must be("GBAUFXTFXTFXT")
+    }
+
+    "render departure movement" in {
+      val arrivalView = view(movements = Seq(depart))
+      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.edl")
+      arrivalView.getElementById("movement_date_0").text() must be("30 October 2019 at 09:17")
+      arrivalView.getElementById("goods_location_0").text() must be("GBAUFDSASFDFDF")
+    }
+
+    "render retrospective arrival" in {
+      val arrivalView = view(movements = Seq(retro))
+      arrivalView.getElementById("movement_type_0") must containMessage("ileQueryResponse.previousMovements.type.ret")
+      arrivalView.getElementById("movement_date_0").text() must be("4 November 2019 at 16:27")
+      arrivalView.getElementById("goods_location_0").text() must be("GBAUDFGFSHFKD")
+    }
+
+    "render movements by date order" in {
+      val movementsView = view(movements = Seq(arrival, retro, depart))
+      movementsView.getElementById("movement_date_0").text() must be("4 November 2019 at 16:27")
+      movementsView.getElementById("movement_date_1").text() must be("30 October 2019 at 09:17")
+      movementsView.getElementById("movement_date_2").text() must be("23 October 2019 at 13:34")
+    }
+
+  }
+}


### PR DESCRIPTION
- Omit table rows with no values (codes)
- Hide movements table when empty
- Move submit button & link up under Queried UCR section

- Fixed bug whereby unknown route of entry was displayed as "Unknown"
rather than "<code> - Unknown"

- Took the opportunity to break up the existing view specs in favour of
smaller tests for each component.