### PR TITLE
CEDS-2057 - Rename the Export services

### DIFF
--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1,4 +1,4 @@
-service.name = Internal Exports Movements Service
+service.name = CDS Exports Service
 header.homepage.alt = Go to the HMRC homepage
 header.homepage.text = HM Revenue & Customs
 


### PR DESCRIPTION
A consistent naming convention must be displayed across all three CDS Exports services to provide users for a simplified experience and understanding.

The CDS Movements Exports service was modified to:

1) the service name changed to CDS Exports in the banners at the top of each page,
2) the service name changed to CDS Exports on the start page.