### PR TITLE
CEDS-2057 - Rename the Export services

### DIFF
--- a/app/controllers/consolidations/ShutMucrController.scala
+++ b/app/controllers/consolidations/ShutMucrController.scala
@@ -18,6 +18,7 @@ package controllers.consolidations
 
 import controllers.actions.{AuthenticatedAction, JourneyRefiner}
 import controllers.consolidations.{routes => consolidationsRoutes}
+import forms.ShutMucr
 import forms.ShutMucr.form
 import javax.inject.{Inject, Singleton}
 import models.cache.{Cache, JourneyType, ShutMucrAnswers}
@@ -40,7 +41,7 @@ class ShutMucrController @Inject()(
     extends FrontendController(mcc) with I18nSupport {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen getJourney(JourneyType.SHUT_MUCR)) { implicit request =>
-    val shutMucr = request.answersAs[ShutMucrAnswers].shutMucr
+    val shutMucr: Option[ShutMucr] = request.answersAs[ShutMucrAnswers].shutMucr
     Ok(shutMucrPage(shutMucr.fold(form())(form().fill)))
   }
 

--- a/app/views/components/gds/siteHeader.scala.html
+++ b/app/views/components/gds/siteHeader.scala.html
@@ -23,13 +23,13 @@
 <div class="hmrc-internal-header app-header">
     <div class="govuk-width-container">
         <div class="hmrc-logo app-header__title">
-            <a href="https://www.gov.uk/government/organisations/hm-revenue-customs" title="Go to the HMRC homepage" class="hmrc-logo__link">
-                HM Revenue &amp; Customs
+            <a href="https://www.gov.uk/government/organisations/hm-revenue-customs" title="@messages("header.homepage.alt")" class="hmrc-logo__link">
+                @messages("header.homepage.text")
             </a>
         </div>
         <div class="hmrc-internal-service-name app-header__link">
             <a href="/" title="Go to the Exports Declaration Service homepage" class="hmrc-internal-service-name__link">
-                Internal Exports Movements Service
+                @messages("service.name")
             </a>
         </div>
     </div>


### PR DESCRIPTION
Necessary to fix banners.

A consistent naming convention must be displayed across all three CDS Exports services to provide users for a simplified experience and understanding.

The CDS Movements Exports service was modified to:

1) the service name changed to CDS Exports in the banners at the top of each page,
2) the service name changed to CDS Exports on the start page.