### PR TITLE
CEDS-2199 - Prevent changes to UCR when Managing Consignment

### DIFF
--- a/app/views/shutmucr/shut_mucr_summary.scala.html
+++ b/app/views/shutmucr/shut_mucr_summary.scala.html
@@ -44,16 +44,7 @@
                         ),
                         value = Value(
                             content = Text(mucr)
-                        ),
-                        actions = Some(Actions(
-                            items = Seq(
-                                ActionItem(
-                                    href = s"${controllers.ileQuery.routes.FindConsignmentController.displayQueryForm()}",
-                                    content = Text(messages("site.change")),
-                                    visuallyHiddenText = Some(messages("site.change.hint.disassociate.ucr", mucr.toUpperCase()))
-                                )
-                            )
-                        ))
+                        )
                     )
                 ),
                 classes = "govuk-!-margin-bottom-9"

--- a/test/unit/views/shutmucr/ShutMucrSummaryViewSpec.scala
+++ b/test/unit/views/shutmucr/ShutMucrSummaryViewSpec.scala
@@ -41,13 +41,6 @@ class ShutMucrSummaryViewSpec extends ViewSpec with Injector {
       page(shutMucr).getElementsByClass("govuk-summary-list__value").text() mustBe shutMucr
     }
 
-    "render correct change button" in {
-      val changeButton = page(shutMucr).getElementsByClass("govuk-link").first()
-
-      changeButton must haveHref(controllers.ileQuery.routes.FindConsignmentController.displayQueryForm())
-      changeButton.text() must include(messages("site.edit"))
-    }
-
     "render correct submit button" in {
       val submitButton = page(shutMucr).getElementsByClass("govuk-button").first()
 


### PR DESCRIPTION
**Shut Mucr page change button removed.**

The Internal and External Movements Services are being changed to force users to query before performing an action in order to reduce the risk that a movement is inadvertently performed against the wrong UCR. Therefore, it doesn't make sense to give users the option to change the UCR when managing the queried consignment.

After searching for a valid UCR and proceeding to the next page via  'Manage this Consignment' button, following any action to perform against this UCR (e.g. Arrive, Depart, Shut, Disassociate, Retrospective Arrival), it must be not possible to change the UCR.