### PR TITLE
CEDS-2109 Remove the Secure and HttpOnly config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -34,8 +34,6 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
 play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.FrontendFilters"
-play.http.flash.secure = true
-play.http.flash.httpOnly = true
 
 # Default http client
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"


### PR DESCRIPTION
This is due to the Acceptance tests failing due to not being able to set
the secure PLAY_FLASH cookie when using the `http` protocol
Instead these configs need to be added to the relevat `app-config` repos