### PR TITLE
CEDS-2612 - auto-complete drop-down arrow location relative to font size

### DIFF
--- a/app/assets/stylesheets/partials/_autocomplete.scss
+++ b/app/assets/stylesheets/partials/_autocomplete.scss
@@ -7,3 +7,7 @@ body {
 table {
   font-size: 1em;
 }
+
+svg.autocomplete__dropdown-arrow-down {
+  top : 0.6rem;
+}

--- a/app/views/ducr_part_details.scala.html
+++ b/app/views/ducr_part_details.scala.html
@@ -51,7 +51,8 @@
     @exportsInputText(
       field = form("ducr"),
       labelKey = "ducrPartDetails.ducr",
-      hintKey = Some("ducrPartDetails.ducr.hint")
+      hintKey = Some("ducrPartDetails.ducr.hint"),
+      inputClasses = "govuk-input--width-20"
     )
 
     @exportsInputText(


### PR DESCRIPTION
Change find Ducr Part input field to width-20 (works better with larger fonts)