### PR TITLE
CEDS-2614 Change Summary pages to full width

### DIFF
--- a/app/views/associateucr/associate_ucr_summary.scala.html
+++ b/app/views/associateucr/associate_ucr_summary.scala.html
@@ -75,7 +75,9 @@
 
 @govukLayout(
   title = Title("associate.ucr.summary.title"),
-  backButton = Some(BackButton(messages("site.back"), backCall))) {
+  backButton = Some(BackButton(messages("site.back"), backCall)),
+  useCustomContentWidth = true
+) {
 
   @formHelper(action = consolidations.routes.AssociateUcrSummaryController.submit(), 'autoComplete -> "off") {
 

--- a/app/views/disassociateucr/disassociate_ucr_summary.scala.html
+++ b/app/views/disassociateucr/disassociate_ucr_summary.scala.html
@@ -31,7 +31,9 @@ formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
 
 @govukLayout(
     title = Title("disassociate.ucr.summary.title"),
-    backButton = Some(BackButton(messages("site.back"), controllers.routes.ChoiceController.displayPage())))  {
+    backButton = Some(BackButton(messages("site.back"), controllers.routes.ChoiceController.displayPage())),
+    useCustomContentWidth = true
+) {
 
     @formHelper(action = consolidations.routes.DisassociateUcrSummaryController.submit(), 'autoComplete -> "off") {
 

--- a/app/views/shutmucr/shut_mucr_summary.scala.html
+++ b/app/views/shutmucr/shut_mucr_summary.scala.html
@@ -29,7 +29,9 @@
 
 @govukLayout(
     title = Title("shutMucr.summary.title"),
-    backButton = Some(BackButton(messages("site.back"), controllers.routes.ChoiceController.displayPage))) {
+    backButton = Some(BackButton(messages("site.back"), controllers.routes.ChoiceController.displayPage)),
+    useCustomContentWidth = true
+) {
 
     @formHelper(action = consolidations.routes.ShutMucrSummaryController.submit(), 'autoComplete -> "off") {
 

--- a/app/views/summary/arrival_summary_page.scala.html
+++ b/app/views/summary/arrival_summary_page.scala.html
@@ -39,7 +39,9 @@
 
 @govukLayout(
   title = Title("summary.arrival.title"),
-  backButton = Some(BackButton(messages("site.back"), routes.LocationController.displayPage))) {
+  backButton = Some(BackButton(messages("site.back"), routes.LocationController.displayPage)),
+  useCustomContentWidth = true
+) {
 
     @formHelper(action = routes.MovementSummaryController.submitMovementRequest(), 'autoComplete -> "off") {
 

--- a/app/views/summary/departure_summary_page.scala.html
+++ b/app/views/summary/departure_summary_page.scala.html
@@ -41,7 +41,9 @@
 
 @govukLayout(
   title = Title("summary.departure.title"),
-  backButton = Some(BackButton(messages("site.back"), routes.TransportController.displayPage))) {
+  backButton = Some(BackButton(messages("site.back"), routes.TransportController.displayPage)),
+  useCustomContentWidth = true
+) {
 
     @formHelper(action = routes.MovementSummaryController.submitMovementRequest(), 'autoComplete -> "off") {
 

--- a/app/views/summary/retrospective_arrival_summary_page.scala.html
+++ b/app/views/summary/retrospective_arrival_summary_page.scala.html
@@ -36,7 +36,9 @@
 
 @govukLayout(
   title = Title("summary.retrospectiveArrival.title"),
-  backButton = Some(BackButton(messages("site.back"), routes.LocationController.displayPage))) {
+  backButton = Some(BackButton(messages("site.back"), routes.LocationController.displayPage)),
+  useCustomContentWidth = true
+) {
 
     @formHelper(action = routes.MovementSummaryController.submitMovementRequest(), 'autoComplete -> "off") {
 


### PR DESCRIPTION
This change is to make Summary pages more accessible when used with
double-sized font.
Many words were split into multiple lines which was an issue.