### PR TITLE
CEDS-2667 Add HMRCReportTechnicalssue component

### DIFF
--- a/app/assets/stylesheets/customsdecexfrontend-app.scss
+++ b/app/assets/stylesheets/customsdecexfrontend-app.scss
@@ -52,6 +52,7 @@ $govuk-assets-path: '/customs-exports-internal/assets/';
 $govuk-images-path: "/customs-exports-internal/assets/lib/govuk-frontend/govuk/assets/images/";
 $govuk-fonts-path: "/customs-exports-internal/assets/lib/govuk-frontend/govuk/assets/fonts/";
 @import 'lib/govuk-frontend/govuk/all';
+@import "lib/hmrc-frontend/hmrc/all";
 @import 'lib/accessible-autocomplete/dist/accessible-autocomplete.min';
 
 @import 'partials/_step-by-step-navigation';

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -49,6 +49,8 @@ class AppConfig @Inject()(
       .getOptional[String](key)
       .getOrElse(throw new Exception(s"Missing configuration key: $key"))
 
+  lazy val appName: String = serviceIdentifier
+
   lazy val customsDeclareExportsMovementsUrl: String = servicesConfig.baseUrl("customs-declare-exports-movements")
 
   lazy val customsDeclarationsGoodsTakenOutOfEuUrl: String = loadConfig("urls.customsDeclarationsGoodsTakenOutOfEu")

--- a/app/views/components/gds/gds_main_template.scala.html
+++ b/app/views/components/gds/gds_main_template.scala.html
@@ -19,9 +19,13 @@
 @import components.gds.{phaseBanner, siteHeader}
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.html.components.implicits._
+@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcReportTechnicalIssue
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.reporttechnicalissue.ReportTechnicalIssue
+@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Cy}
 @import views.Title
 @import views.components.BackButton
 @import views.html.components.gds.{govukFlexibleLayout, timeoutDialog}
+@import config.AppConfig
 
 @this(
   govukHeader: GovukHeader,
@@ -31,8 +35,11 @@
   govukBackLink: GovukBackLink,
   siteHeader: siteHeader,
   phaseBanner: phaseBanner,
-  timeoutDialogConfig: TimeoutDialogConfig
+  timeoutDialogConfig: TimeoutDialogConfig,
+  hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
+  appConfig: AppConfig
 )
+
 
 @(
   title: Title,
@@ -80,6 +87,11 @@
         )))
     </div>
     @contentBlock
+    @hmrcReportTechnicalIssue(
+        ReportTechnicalIssue(
+            serviceCode = appConfig.appName,
+            language = if(messages.lang.code == "en") En else Cy)
+    )
 }
 
 @footer = @{

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,6 +11,7 @@ object AppDependencies {
     "uk.gov.hmrc"          %% "play-ui"                       % "8.11.0-play-26",
     "uk.gov.hmrc"          %% "bootstrap-frontend-play-26"    % "2.24.0",
     "uk.gov.hmrc"          %% "play-frontend-govuk"           % "0.49.0-play-26",
+    "uk.gov.hmrc"          %% "play-frontend-hmrc"            % "0.26.0-play-26",
     "org.webjars.npm"      %  "govuk-frontend"                % "3.8.1",
     "uk.gov.hmrc"          %% "play-json-union-formatter"     % "1.10.0-play-26",
     "uk.gov.hmrc"          %% "simple-reactivemongo"          % "7.30.0-play-26",
@@ -18,7 +19,7 @@ object AppDependencies {
     "com.github.tototoshi" %% "scala-csv"                     % "1.3.6",
     "com.github.cloudyrock.mongock"  %  "mongock-core"        % "2.0.2",
     "org.mongodb"          %  "mongo-java-driver"             % "3.12.1",
-    "org.webjars.npm"      %  "hmrc-frontend"                 % "1.5.0",
+    "org.webjars.npm"      %  "hmrc-frontend"                 % "1.20.0",
     "org.webjars.npm"      %  "accessible-autocomplete"       % "2.0.3"
   ).map(_.withSources())
 


### PR DESCRIPTION
This component is a non-ajax implementation and is the recommended
approach by the HMRC Play UI team, since the previous "GetHelpLink" was
not accessible.

This component does not work locally and it should simply open a new
page. We have been told that this will work in all the other
environments.