### PR TITLE
Ceds 2897

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -133,7 +133,7 @@ urls {
 
 features {
   default: disabled
-  ducrPart: disabled
+  ducrPart: enabled
 }
 
 timeoutDialog {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -15,7 +15,7 @@
 include "frontend.conf"
 
 appName = "customs-exports-internal-frontend"
-application.router = testOnlyDoNotUseInAppConf.Routes
+play.http.router = testOnlyDoNotUseInAppConf.Routes
 
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
@@ -133,7 +133,7 @@ urls {
 
 features {
   default: disabled
-  ducrPart: enabled
+  ducrPart: disabled
 }
 
 timeoutDialog {


### PR DESCRIPTION
Updating deprecated key
See [blogpost](https://confluence.tools.tax.service.gov.uk/display/TEC/2020/12/01/Cleanup+deprecated+Play+framework+configuration+keys)