### PR TITLE
CEDS-2771 Validate MUCR length is <36 characters long

### DIFF
--- a/app/utils/FieldValidator.scala
+++ b/app/utils/FieldValidator.scala
@@ -59,7 +59,7 @@ object FieldValidator {
   val validMucr: String => Boolean = (input: String) =>
     input.matches("""GB/[0-9A-Z]{3,4}-[0-9A-Z]{5,28}|GB/[0-9A-Z]{9,12}-[0-9A-Z]{1,23}|A:[0-9A-Z]{3}[0-9]{8}|C:[A-Z]{3}[0-9A-Z]{3,30}""")
 
-  val validMucrIgnoreCase: String => Boolean = (input: String) => validMucr(input.toUpperCase)
+  val validMucrIgnoreCase: String => Boolean = (input: String) => validMucr(input.toUpperCase) && noLongerThan(35)(input)
 
   private val zerosOnlyRegexValue = "[0]+"
   private val noMoreDecimalPlacesThanRegexValue: Int => String =

--- a/test/unit/forms/AssociateUcrSpec.scala
+++ b/test/unit/forms/AssociateUcrSpec.scala
@@ -17,26 +17,45 @@
 package forms
 
 import base.UnitSpec
+import play.api.data.FormError
 import play.api.libs.json.{JsObject, JsString}
 
 class AssociateUcrSpec extends UnitSpec {
 
   "AssociateUcr" should {
 
-    "convert ducr to upper case" in {
+    "convert to upper case" when {
+      "provided with Ducr" in {
 
-      val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("ducr"), "ducr" -> JsString("8gb123457359100-test0001"))))
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("ducr"), "ducr" -> JsString("8gb123457359100-test0001"))))
 
-      form.errors mustBe empty
-      form.value.map(_.ucr) must be(Some("8GB123457359100-TEST0001"))
+        form.errors mustBe empty
+        form.value.map(_.ucr) must be(Some("8GB123457359100-TEST0001"))
+      }
+
+      "provided with Mucr" in {
+
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test"))))
+
+        form.errors mustBe empty
+        form.value.map(_.ucr) must be(Some("GB/ABCED1234-15804TEST"))
+      }
+
+      "provided with Mucr that is 35 characters long" in {
+
+        val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test1234567890123"))))
+
+        form.errors mustBe empty
+        form.value.map(_.ucr) must be(Some("GB/ABCED1234-15804TEST1234567890123"))
+      }
     }
+  }
+  "return an error" when {
+    "provided with Mucr that is over 35 characters long" in {
 
-    "convert mucr to upper case" in {
+      val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test12345678901234"))))
 
-      val form = AssociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test"))))
-
-      form.errors mustBe empty
-      form.value.map(_.ucr) must be(Some("GB/ABCED1234-15804TEST"))
+      form.errors mustBe Seq(FormError("mucr", List("mucr.error.format")))
     }
   }
 }

--- a/test/unit/forms/ConsignmentReferencesSpec.scala
+++ b/test/unit/forms/ConsignmentReferencesSpec.scala
@@ -65,6 +65,13 @@ class ConsignmentReferencesSpec extends UnitSpec {
       errors must be(Seq(FormError("mucrValue", "consignmentReferences.reference.mucrValue.error")))
     }
 
+    "have error for Mucr length > 35 characters" in {
+      val inputData = ConsignmentReferences(ConsignmentReferenceType.M, "GB/82F9-0N2F6500040010TO120P0A300689")
+      val errors = ConsignmentReferences.form().fillAndValidate(inputData).errors
+
+      errors must be(Seq(FormError("mucrValue", "consignmentReferences.reference.mucrValue.error")))
+    }
+
     "convert ducr to upper case" in {
 
       val form = ConsignmentReferences.form.bind(JsObject(Map("reference" -> JsString("D"), "ducrValue" -> JsString("8gb123457359100-test0001"))))
@@ -79,6 +86,15 @@ class ConsignmentReferencesSpec extends UnitSpec {
 
       form.errors mustBe empty
       form.value.map(_.referenceValue) must be(Some("GB/ABCED1234-15804TEST"))
+    }
+
+    "convert mucr that is 35 characters long to upper case" in {
+
+      val form =
+        ConsignmentReferences.form.bind(JsObject(Map("reference" -> JsString("M"), "mucrValue" -> JsString("gb/abced1234-15804test1234567890123"))))
+
+      form.errors mustBe empty
+      form.value.map(_.referenceValue) must be(Some("GB/ABCED1234-15804TEST1234567890123"))
     }
   }
 }

--- a/test/unit/forms/DisassociateUcrSpec.scala
+++ b/test/unit/forms/DisassociateUcrSpec.scala
@@ -17,26 +17,47 @@
 package forms
 
 import base.UnitSpec
+import play.api.data.FormError
 import play.api.libs.json.{JsObject, JsString}
 
 class DisassociateUcrSpec extends UnitSpec {
 
   "DisassociateUcr" should {
 
-    "convert ducr to upper case" in {
+    "convert to upper case" when {
+      "provided with Ducr" in {
 
-      val form = DisassociateUcr.form.bind(JsObject(Map("kind" -> JsString("ducr"), "ducr" -> JsString("8gb123457359100-test0001"))))
+        val form = DisassociateUcr.form.bind(JsObject(Map("kind" -> JsString("ducr"), "ducr" -> JsString("8gb123457359100-test0001"))))
 
-      form.errors mustBe empty
-      form.value.map(_.ucr) must be(Some("8GB123457359100-TEST0001"))
-    }
+        form.errors mustBe empty
+        form.value.map(_.ucr) must be(Some("8GB123457359100-TEST0001"))
+      }
 
-    "convert mucr to upper case" in {
+      "provided with Mucr" in {
 
-      val form = DisassociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test"))))
+        val form = DisassociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test"))))
 
-      form.errors mustBe empty
-      form.value.map(_.ucr) must be(Some("GB/ABCED1234-15804TEST"))
+        form.errors mustBe empty
+        form.value.map(_.ucr) must be(Some("GB/ABCED1234-15804TEST"))
+      }
+
+      "provided with Mucr that is 35 characters long" in {
+
+        val form = DisassociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test1234567890123"))))
+
+        form.errors mustBe empty
+        form.value.map(_.ucr) must be(Some("GB/ABCED1234-15804TEST1234567890123"))
+      }
     }
   }
+
+  "return an error" when {
+    "provided with Mucr that is over 35 characters long" in {
+
+      val form = DisassociateUcr.form.bind(JsObject(Map("kind" -> JsString("mucr"), "mucr" -> JsString("gb/abced1234-15804test12345678901234"))))
+
+      form.errors mustBe Seq(FormError("mucr", "disassociate.ucr.mucr.error"))
+    }
+  }
+
 }

--- a/test/unit/forms/IleQueryFormSpec.scala
+++ b/test/unit/forms/IleQueryFormSpec.scala
@@ -17,6 +17,7 @@
 package forms
 
 import base.UnitSpec
+import play.api.data.FormError
 import play.api.libs.json.{JsObject, JsString}
 
 class IleQueryFormSpec extends UnitSpec {
@@ -38,6 +39,20 @@ class IleQueryFormSpec extends UnitSpec {
       form.errors mustBe (empty)
       form.value must be(Some("GB/ABCED1234-15804TEST"))
     }
-  }
 
+    "convert mucr to upper case when is 35 characters long" in {
+
+      val form = IleQueryForm.form.bind(JsObject(Map("ucr" -> JsString("gb/82f9-0n2f6500040010tO120p0a30998"))))
+
+      form.errors mustBe (empty)
+      form.value must be(Some("GB/82F9-0N2F6500040010TO120P0A30998"))
+    }
+
+    "display error when mucr is over 35 characters long" in {
+
+      val form = IleQueryForm.form.bind(JsObject(Map("ucr" -> JsString("gb/82f9-0n2f6500040010tO120p0a309989"))))
+
+      form.errors must be(Seq(FormError("ucr", "ileQuery.ucr.incorrect")))
+    }
+  }
 }

--- a/test/unit/forms/ShutMucrSpec.scala
+++ b/test/unit/forms/ShutMucrSpec.scala
@@ -49,6 +49,14 @@ class ShutMucrSpec extends UnitSpec {
 
         errors mustBe Seq(FormError("mucr", "error.mucr.format"))
       }
+
+      "MUCR length is over 35 characters long" in {
+
+        val errors = ShutMucr.form().bind(JsObject(Map("mucr" -> JsString("gb/abced1234-15804test12345678901234")))).errors
+
+        errors.length must be(1)
+        errors.head must equal(FormError("mucr", "error.mucr.format"))
+      }
     }
 
     "not contain any errors" when {
@@ -64,11 +72,18 @@ class ShutMucrSpec extends UnitSpec {
 
     "convert to upper case" when {
 
-      "provided MUCR is lower case" in {
+      "MUCR is on lower case" in {
         val form = ShutMucr.form.bind(JsObject(Map("mucr" -> JsString("gb/abced1234-15804test"))))
 
         form.errors mustBe (empty)
         form.value.map(_.mucr) must be(Some("GB/ABCED1234-15804TEST"))
+      }
+
+      "MUCR is on lower case and is 35 characters long" in {
+        val form = ShutMucr.form.bind(JsObject(Map("mucr" -> JsString("gb/abced1234-15804test1234567890123"))))
+
+        form.errors mustBe (empty)
+        form.value.map(_.mucr) must be(Some("GB/ABCED1234-15804TEST1234567890123"))
       }
     }
   }


### PR DESCRIPTION
Recently we have encountered the issue with following MUCR:

   `GB/82F9-0N2F6500040010TO120P0A300689` (36 characters long)

It complies with our regex but it was over 35 characters long and ILE
rejected for being too long.
After speaking with the QAs we have determined that the regex requires
an overal length validation.

The approach taken was not to overload the existing regex, it is already
too complex to read and instead add a separate validation on it's
length.