### PR TITLE
[CEDS-3162] Plug JQuery Vulnerability

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -122,7 +122,7 @@ google-analytics {
 }
 
 assets {
-  version = "3.3.2"
+  version = "3.17.0"
   url = "http://localhost:9032/assets/"
 }
 


### PR DESCRIPTION
Upgrade of assets-frontend repository from 3.3.2 -> 3.17.0 to
plug a security vulnerability hilighted by the recent pen test.