### PR TITLE
CEDS-3163 Remove authentication from /sign-out endpoint

### DIFF
--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -15,22 +15,19 @@
  */
 
 package controllers
-import controllers.actions.AuthenticatedAction
-import javax.inject.Inject
+
 import models.SignOutReason
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.{session_timed_out, user_signed_out}
 
-class SignOutController @Inject()(
-  authenticate: AuthenticatedAction,
-  mcc: MessagesControllerComponents,
-  sessionTimedOut: session_timed_out,
-  userSignedOutPage: user_signed_out
-) extends FrontendController(mcc) with I18nSupport {
+import javax.inject.Inject
 
-  def signOut(signOutReason: SignOutReason): Action[AnyContent] = authenticate { _ =>
+class SignOutController @Inject()(mcc: MessagesControllerComponents, sessionTimedOut: session_timed_out, userSignedOutPage: user_signed_out)
+    extends FrontendController(mcc) with I18nSupport {
+
+  def signOut(signOutReason: SignOutReason): Action[AnyContent] = Action { _ =>
     val redirectionTarget: Call = signOutReason match {
       case SignOutReason.SessionTimeout => routes.SignOutController.sessionTimeoutSignedOut()
       case SignOutReason.UserAction     => routes.SignOutController.userSignedOut()

--- a/test/unit/controllers/SignOutControllerSpec.scala
+++ b/test/unit/controllers/SignOutControllerSpec.scala
@@ -16,10 +16,9 @@
 
 package controllers
 
-import controllers.actions.AuthenticatedAction
 import models.SignOutReason
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, verify, verifyNoMoreInteractions, when}
+import org.mockito.Mockito.{reset, verify, when}
 import org.scalatest.concurrent.ScalaFutures
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
@@ -27,12 +26,11 @@ import views.html.{session_timed_out, user_signed_out}
 
 class SignOutControllerSpec extends ControllerLayerSpec with ScalaFutures {
 
-  private val authAction = mock[AuthenticatedAction]
   private val mcc = stubMessagesControllerComponents()
   private val sessionTimedOutPage = mock[session_timed_out]
   private val userSignedOutPage = mock[user_signed_out]
 
-  private val controller = new SignOutController(SuccessfulAuth(), mcc, sessionTimedOutPage, userSignedOutPage)
+  private val controller = new SignOutController(mcc, sessionTimedOutPage, userSignedOutPage)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -42,7 +40,6 @@ class SignOutControllerSpec extends ControllerLayerSpec with ScalaFutures {
   }
 
   override def afterEach(): Unit = {
-    reset(authAction)
     reset(sessionTimedOutPage)
     reset(userSignedOutPage)
 
@@ -88,14 +85,7 @@ class SignOutControllerSpec extends ControllerLayerSpec with ScalaFutures {
 
   "SignOutController on sessionTimeoutSignedOut" should {
 
-    val controller = new SignOutController(authAction, mcc, sessionTimedOutPage, userSignedOutPage)
-
-    "not authenticate request" in {
-
-      controller.sessionTimeoutSignedOut()(getRequest).futureValue
-
-      verifyNoMoreInteractions(authAction)
-    }
+    val controller = new SignOutController(mcc, sessionTimedOutPage, userSignedOutPage)
 
     "call sessionTimedOutPage" in {
 
@@ -114,14 +104,7 @@ class SignOutControllerSpec extends ControllerLayerSpec with ScalaFutures {
 
   "SignOutController on userSignedOut" should {
 
-    val controller = new SignOutController(authAction, mcc, sessionTimedOutPage, userSignedOutPage)
-
-    "not authenticate request" in {
-
-      controller.userSignedOut()(getRequest).futureValue
-
-      verifyNoMoreInteractions(authAction)
-    }
+    val controller = new SignOutController(mcc, sessionTimedOutPage, userSignedOutPage)
 
     "call userSignedOutPage" in {
 


### PR DESCRIPTION
Authentication on this endpoint is not necessary, as the
session is removed on this endpoint anyway.
Additionally, requirement to be authenticated on this
endpoint was causing random problems, because sometimes
user was asked to log-in to be then logged out. This
was probably due to auth cookie timing out slightly
before this endpoint was hit.