### PR TITLE
CEDS-4532 Update reads and writes for Cache

### DIFF
--- a/app/models/cache/Cache.scala
+++ b/app/models/cache/Cache.scala
@@ -17,7 +17,9 @@
 package models.cache
 
 import models.{now, UcrBlock}
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json._
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
 
@@ -26,7 +28,24 @@ case class Cache(providerId: String, answers: Option[Answers], queryUcr: Option[
 }
 
 object Cache {
-  implicit val format: OFormat[Cache] = Json.format[Cache]
+  private val stringDateReads: Reads[Instant] = implicitly[Reads[String]].map(Instant.parse)
+
+  private val mongoDateReads: Reads[Instant] = MongoJavatimeFormats.instantReads
+
+  private val instantReads: Reads[Instant] = mongoDateReads orElse stringDateReads
+
+  implicit val formatWrites: Writes[Instant] = MongoJavatimeFormats.instantWrites
+
+  implicit val reads: Reads[Cache] = (
+    (JsPath \ "providerId").read[String] and
+      (JsPath \ "answers").readNullable[Answers] and
+      (JsPath \ "queryUcr").readNullable[UcrBlock] and
+      (JsPath \ "updated").readNullable[Instant](instantReads)
+  )(new Cache(_, _, _, _))
+
+  implicit val writes: OWrites[Cache] = Json.writes[Cache]
+
+  implicit val format: OFormat[Cache] = OFormat(reads, writes)
 
   def apply(providerId: String, queryUcr: UcrBlock): Cache = new Cache(providerId, None, Some(queryUcr))
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,9 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 


### PR DESCRIPTION
Add defensive reads so that updated fields is read as a string or Date

Ensure all new records are written with a Date to the updated field